### PR TITLE
Update Node.js Docker image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build frontend
-FROM node:22.13.0-alpine3.21@sha256:8e08de1d4e1a18be0f8628674222e122d555744f13c94fafaf716148eb665428 AS frontend
+FROM node:22-alpine3.21@sha256:af8023ec879993821f6d5b21382ed915622a1b0f1cc03dbeb6804afaf01f8885 AS frontend
 
 WORKDIR /app/frontend
 


### PR DESCRIPTION
## Summary
- The pinned `node:22.13.0-alpine3.21` digest was removed from Docker Hub, causing the container build to fail
- Updated to the current `node:22-alpine3.21` image with a valid digest

## Test plan
- [ ] Verify the GitHub Actions container build passes