### PR TITLE
Add TOTP-based two-factor authentication

### DIFF
--- a/internal/handler/totp_test.go
+++ b/internal/handler/totp_test.go
@@ -1,0 +1,938 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/amalgamated-tools/enlace/internal/handler"
+	"github.com/amalgamated-tools/enlace/internal/middleware"
+	"github.com/amalgamated-tools/enlace/internal/service"
+)
+
+// mockTOTPService implements handler.TOTPServiceInterface for testing.
+type mockTOTPService struct {
+	beginSetupFn              func(ctx context.Context, userID string) (string, string, string, error)
+	confirmSetupFn            func(ctx context.Context, userID, code string) ([]string, error)
+	verifyFn                  func(ctx context.Context, userID, code string) error
+	verifyRecoveryCodeFn      func(ctx context.Context, userID, code string) error
+	disableFn                 func(ctx context.Context, userID string) error
+	regenerateRecoveryCodesFn func(ctx context.Context, userID string) ([]string, error)
+	getStatusFn               func(ctx context.Context, userID string) (bool, error)
+	generatePendingTokenFn    func(userID string, isAdmin bool) (string, error)
+	validatePendingTokenFn    func(tokenStr string) (*service.Claims, error)
+}
+
+func (m *mockTOTPService) BeginSetup(ctx context.Context, userID string) (string, string, string, error) {
+	if m.beginSetupFn != nil {
+		return m.beginSetupFn(ctx, userID)
+	}
+	return "", "", "", errors.New("not implemented")
+}
+
+func (m *mockTOTPService) ConfirmSetup(ctx context.Context, userID, code string) ([]string, error) {
+	if m.confirmSetupFn != nil {
+		return m.confirmSetupFn(ctx, userID, code)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockTOTPService) Verify(ctx context.Context, userID, code string) error {
+	if m.verifyFn != nil {
+		return m.verifyFn(ctx, userID, code)
+	}
+	return errors.New("not implemented")
+}
+
+func (m *mockTOTPService) VerifyRecoveryCode(ctx context.Context, userID, code string) error {
+	if m.verifyRecoveryCodeFn != nil {
+		return m.verifyRecoveryCodeFn(ctx, userID, code)
+	}
+	return errors.New("not implemented")
+}
+
+func (m *mockTOTPService) Disable(ctx context.Context, userID string) error {
+	if m.disableFn != nil {
+		return m.disableFn(ctx, userID)
+	}
+	return errors.New("not implemented")
+}
+
+func (m *mockTOTPService) RegenerateRecoveryCodes(ctx context.Context, userID string) ([]string, error) {
+	if m.regenerateRecoveryCodesFn != nil {
+		return m.regenerateRecoveryCodesFn(ctx, userID)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockTOTPService) GetStatus(ctx context.Context, userID string) (bool, error) {
+	if m.getStatusFn != nil {
+		return m.getStatusFn(ctx, userID)
+	}
+	return false, errors.New("not implemented")
+}
+
+func (m *mockTOTPService) GeneratePendingToken(userID string, isAdmin bool) (string, error) {
+	if m.generatePendingTokenFn != nil {
+		return m.generatePendingTokenFn(userID, isAdmin)
+	}
+	return "", errors.New("not implemented")
+}
+
+func (m *mockTOTPService) ValidatePendingToken(tokenStr string) (*service.Claims, error) {
+	if m.validatePendingTokenFn != nil {
+		return m.validatePendingTokenFn(tokenStr)
+	}
+	return nil, errors.New("not implemented")
+}
+
+// mockPasswordVerifier implements handler.PasswordVerifier for testing.
+type mockPasswordVerifier struct {
+	verifyPasswordFn func(ctx context.Context, userID, password string) error
+}
+
+func (m *mockPasswordVerifier) VerifyPassword(ctx context.Context, userID, password string) error {
+	if m.verifyPasswordFn != nil {
+		return m.verifyPasswordFn(ctx, userID, password)
+	}
+	return errors.New("not implemented")
+}
+
+// setupTOTPRouter creates a chi router with TOTP routes for testing.
+// Authenticated routes under /me/2fa inject a test user ID into the context.
+func setupTOTPRouter(h *handler.TOTPHandler) *chi.Mux {
+	r := chi.NewRouter()
+	// Inject test user ID for authenticated routes
+	r.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), middleware.UserIDKey, "test-user-123")
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	})
+	r.Route("/me/2fa", func(r chi.Router) {
+		r.Get("/status", h.GetStatus)
+		r.Post("/setup", h.BeginSetup)
+		r.Post("/confirm", h.ConfirmSetup)
+		r.Post("/disable", h.Disable)
+		r.Post("/recovery-codes", h.RegenerateRecoveryCodes)
+	})
+	r.Route("/auth/2fa", func(r chi.Router) {
+		r.Post("/verify", h.Verify)
+		r.Post("/recovery", h.Recovery)
+	})
+	return r
+}
+
+// --- Authenticated endpoints: /me/2fa ---
+
+func TestTOTPHandler_GetStatus_Success(t *testing.T) {
+	totpMock := &mockTOTPService{
+		getStatusFn: func(ctx context.Context, userID string) (bool, error) {
+			return false, nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	req := httptest.NewRequest(http.MethodGet, "/me/2fa/status", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Enabled    bool `json:"enabled"`
+			Require2FA bool `json:"require_2fa"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+	if response.Data.Enabled {
+		t.Error("expected enabled to be false")
+	}
+	if response.Data.Require2FA {
+		t.Error("expected require_2fa to be false")
+	}
+}
+
+func TestTOTPHandler_GetStatus_Enabled(t *testing.T) {
+	totpMock := &mockTOTPService{
+		getStatusFn: func(ctx context.Context, userID string) (bool, error) {
+			return true, nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, true)
+	router := setupTOTPRouter(h)
+
+	req := httptest.NewRequest(http.MethodGet, "/me/2fa/status", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Enabled    bool `json:"enabled"`
+			Require2FA bool `json:"require_2fa"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+	if !response.Data.Enabled {
+		t.Error("expected enabled to be true")
+	}
+	if !response.Data.Require2FA {
+		t.Error("expected require_2fa to be true")
+	}
+}
+
+func TestTOTPHandler_BeginSetup_Success(t *testing.T) {
+	totpMock := &mockTOTPService{
+		beginSetupFn: func(ctx context.Context, userID string) (string, string, string, error) {
+			return "JBSWY3DPEHPK3PXP", "base64-qr-data", "otpauth://totp/Enlace:user@example.com?secret=JBSWY3DPEHPK3PXP", nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/setup", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Secret          string `json:"secret"`
+			QRCode          string `json:"qr_code"`
+			ProvisioningURI string `json:"provisioning_uri"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+	if response.Data.Secret != "JBSWY3DPEHPK3PXP" {
+		t.Errorf("expected secret JBSWY3DPEHPK3PXP, got %s", response.Data.Secret)
+	}
+	if response.Data.QRCode != "base64-qr-data" {
+		t.Errorf("expected qr_code base64-qr-data, got %s", response.Data.QRCode)
+	}
+	if response.Data.ProvisioningURI != "otpauth://totp/Enlace:user@example.com?secret=JBSWY3DPEHPK3PXP" {
+		t.Errorf("expected provisioning_uri otpauth://totp/Enlace:user@example.com?secret=JBSWY3DPEHPK3PXP, got %s", response.Data.ProvisioningURI)
+	}
+}
+
+func TestTOTPHandler_BeginSetup_AlreadyEnabled(t *testing.T) {
+	totpMock := &mockTOTPService{
+		beginSetupFn: func(ctx context.Context, userID string) (string, string, string, error) {
+			return "", "", "", service.ErrTOTPAlreadyEnabled
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/setup", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected status %d, got %d", http.StatusConflict, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}
+
+func TestTOTPHandler_ConfirmSetup_Success(t *testing.T) {
+	totpMock := &mockTOTPService{
+		confirmSetupFn: func(ctx context.Context, userID, code string) ([]string, error) {
+			return []string{"code1", "code2", "code3", "code4", "code5"}, nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"code": "123456"}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/confirm", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			RecoveryCodes []string `json:"recovery_codes"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+	if len(response.Data.RecoveryCodes) != 5 {
+		t.Errorf("expected 5 recovery codes, got %d", len(response.Data.RecoveryCodes))
+	}
+}
+
+func TestTOTPHandler_ConfirmSetup_MissingCode(t *testing.T) {
+	totpMock := &mockTOTPService{}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/confirm", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response struct {
+		Success bool              `json:"success"`
+		Error   string            `json:"error"`
+		Fields  map[string]string `json:"fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+	if _, ok := response.Fields["code"]; !ok {
+		t.Errorf("expected field error for code, got fields: %v", response.Fields)
+	}
+}
+
+func TestTOTPHandler_ConfirmSetup_InvalidCode(t *testing.T) {
+	totpMock := &mockTOTPService{
+		confirmSetupFn: func(ctx context.Context, userID, code string) ([]string, error) {
+			return nil, service.ErrInvalidTOTPCode
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"code": "000000"}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/confirm", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}
+
+func TestTOTPHandler_Disable_Success(t *testing.T) {
+	totpMock := &mockTOTPService{
+		disableFn: func(ctx context.Context, userID string) error {
+			return nil
+		},
+	}
+	pwMock := &mockPasswordVerifier{
+		verifyPasswordFn: func(ctx context.Context, userID, password string) error {
+			return nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, pwMock, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"password": "correct-password"}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/disable", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+}
+
+func TestTOTPHandler_Disable_MissingPassword(t *testing.T) {
+	totpMock := &mockTOTPService{}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/disable", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response struct {
+		Success bool              `json:"success"`
+		Error   string            `json:"error"`
+		Fields  map[string]string `json:"fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+	if _, ok := response.Fields["password"]; !ok {
+		t.Errorf("expected field error for password, got fields: %v", response.Fields)
+	}
+}
+
+func TestTOTPHandler_Disable_WrongPassword(t *testing.T) {
+	totpMock := &mockTOTPService{}
+	pwMock := &mockPasswordVerifier{
+		verifyPasswordFn: func(ctx context.Context, userID, password string) error {
+			return service.ErrInvalidCredentials
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, pwMock, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"password": "wrong-password"}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/disable", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}
+
+func TestTOTPHandler_RegenerateRecoveryCodes_Success(t *testing.T) {
+	totpMock := &mockTOTPService{
+		regenerateRecoveryCodesFn: func(ctx context.Context, userID string) ([]string, error) {
+			return []string{"new1", "new2", "new3", "new4", "new5"}, nil
+		},
+	}
+	pwMock := &mockPasswordVerifier{
+		verifyPasswordFn: func(ctx context.Context, userID, password string) error {
+			return nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, pwMock, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"password": "correct-password"}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/recovery-codes", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			RecoveryCodes []string `json:"recovery_codes"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+	if len(response.Data.RecoveryCodes) != 5 {
+		t.Errorf("expected 5 recovery codes, got %d", len(response.Data.RecoveryCodes))
+	}
+}
+
+func TestTOTPHandler_RegenerateRecoveryCodes_MissingPassword(t *testing.T) {
+	totpMock := &mockTOTPService{}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/recovery-codes", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response struct {
+		Success bool              `json:"success"`
+		Error   string            `json:"error"`
+		Fields  map[string]string `json:"fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+	if _, ok := response.Fields["password"]; !ok {
+		t.Errorf("expected field error for password, got fields: %v", response.Fields)
+	}
+}
+
+func TestTOTPHandler_RegenerateRecoveryCodes_WrongPassword(t *testing.T) {
+	totpMock := &mockTOTPService{}
+	pwMock := &mockPasswordVerifier{
+		verifyPasswordFn: func(ctx context.Context, userID, password string) error {
+			return service.ErrInvalidCredentials
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, pwMock, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"password": "wrong-password"}`
+	req := httptest.NewRequest(http.MethodPost, "/me/2fa/recovery-codes", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}
+
+// --- Public endpoints: /auth/2fa ---
+
+func TestTOTPHandler_Verify_Success(t *testing.T) {
+	totpMock := &mockTOTPService{
+		validatePendingTokenFn: func(tokenStr string) (*service.Claims, error) {
+			return &service.Claims{UserID: "test-user-123", IsAdmin: false, TFA: true}, nil
+		},
+		verifyFn: func(ctx context.Context, userID, code string) error {
+			return nil
+		},
+	}
+	authTokenMock := &mockAuthTokenService{
+		generateTokensFn: func(userID string, isAdmin bool) (*handler.TokenPair, error) {
+			return &handler.TokenPair{AccessToken: "access-token", RefreshToken: "refresh-token"}, nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, authTokenMock, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"pending_token": "pending-token-123", "code": "123456"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/verify", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+	if response.Data.AccessToken != "access-token" {
+		t.Errorf("expected access_token access-token, got %s", response.Data.AccessToken)
+	}
+	if response.Data.RefreshToken != "refresh-token" {
+		t.Errorf("expected refresh_token refresh-token, got %s", response.Data.RefreshToken)
+	}
+}
+
+func TestTOTPHandler_Verify_MissingFields(t *testing.T) {
+	totpMock := &mockTOTPService{}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/verify", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response struct {
+		Success bool              `json:"success"`
+		Error   string            `json:"error"`
+		Fields  map[string]string `json:"fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+	if _, ok := response.Fields["pending_token"]; !ok {
+		t.Errorf("expected field error for pending_token, got fields: %v", response.Fields)
+	}
+	if _, ok := response.Fields["code"]; !ok {
+		t.Errorf("expected field error for code, got fields: %v", response.Fields)
+	}
+}
+
+func TestTOTPHandler_Verify_InvalidPendingToken(t *testing.T) {
+	totpMock := &mockTOTPService{
+		validatePendingTokenFn: func(tokenStr string) (*service.Claims, error) {
+			return nil, errors.New("invalid token")
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"pending_token": "bad-token", "code": "123456"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/verify", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}
+
+func TestTOTPHandler_Verify_InvalidCode(t *testing.T) {
+	totpMock := &mockTOTPService{
+		validatePendingTokenFn: func(tokenStr string) (*service.Claims, error) {
+			return &service.Claims{UserID: "test-user-123", IsAdmin: false, TFA: true}, nil
+		},
+		verifyFn: func(ctx context.Context, userID, code string) error {
+			return service.ErrInvalidTOTPCode
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"pending_token": "pending-token-123", "code": "000000"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/verify", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}
+
+func TestTOTPHandler_Recovery_Success(t *testing.T) {
+	totpMock := &mockTOTPService{
+		validatePendingTokenFn: func(tokenStr string) (*service.Claims, error) {
+			return &service.Claims{UserID: "test-user-123", IsAdmin: false, TFA: true}, nil
+		},
+		verifyRecoveryCodeFn: func(ctx context.Context, userID, code string) error {
+			return nil
+		},
+	}
+	authTokenMock := &mockAuthTokenService{
+		generateTokensFn: func(userID string, isAdmin bool) (*handler.TokenPair, error) {
+			return &handler.TokenPair{AccessToken: "access-token", RefreshToken: "refresh-token"}, nil
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, authTokenMock, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"pending_token": "pending-token-123", "recovery_code": "recovery-code-1"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/recovery", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("expected success to be true")
+	}
+	if response.Data.AccessToken != "access-token" {
+		t.Errorf("expected access_token access-token, got %s", response.Data.AccessToken)
+	}
+	if response.Data.RefreshToken != "refresh-token" {
+		t.Errorf("expected refresh_token refresh-token, got %s", response.Data.RefreshToken)
+	}
+}
+
+func TestTOTPHandler_Recovery_MissingFields(t *testing.T) {
+	totpMock := &mockTOTPService{}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/recovery", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response struct {
+		Success bool              `json:"success"`
+		Error   string            `json:"error"`
+		Fields  map[string]string `json:"fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+	if _, ok := response.Fields["pending_token"]; !ok {
+		t.Errorf("expected field error for pending_token, got fields: %v", response.Fields)
+	}
+	if _, ok := response.Fields["recovery_code"]; !ok {
+		t.Errorf("expected field error for recovery_code, got fields: %v", response.Fields)
+	}
+}
+
+func TestTOTPHandler_Recovery_InvalidPendingToken(t *testing.T) {
+	totpMock := &mockTOTPService{
+		validatePendingTokenFn: func(tokenStr string) (*service.Claims, error) {
+			return nil, errors.New("invalid token")
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"pending_token": "bad-token", "recovery_code": "recovery-code-1"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/recovery", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}
+
+func TestTOTPHandler_Recovery_InvalidCode(t *testing.T) {
+	totpMock := &mockTOTPService{
+		validatePendingTokenFn: func(tokenStr string) (*service.Claims, error) {
+			return &service.Claims{UserID: "test-user-123", IsAdmin: false, TFA: true}, nil
+		},
+		verifyRecoveryCodeFn: func(ctx context.Context, userID, code string) error {
+			return service.ErrInvalidRecoveryCode
+		},
+	}
+
+	h := handler.NewTOTPHandler(totpMock, nil, nil, false)
+	router := setupTOTPRouter(h)
+
+	body := `{"pending_token": "pending-token-123", "recovery_code": "bad-code"}`
+	req := httptest.NewRequest(http.MethodPost, "/auth/2fa/recovery", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+}

--- a/internal/repository/totp.go
+++ b/internal/repository/totp.go
@@ -136,3 +136,47 @@ func (r *TOTPRepository) DeleteRecoveryCodesByUser(ctx context.Context, userID s
 	_, err := r.db.ExecContext(ctx, `DELETE FROM user_recovery_codes WHERE user_id = ?`, userID)
 	return err
 }
+
+// EnableAndSaveRecoveryCodes atomically enables 2FA and stores recovery codes in a single transaction.
+// This prevents a state where 2FA is enabled but no recovery codes exist.
+func (r *TOTPRepository) EnableAndSaveRecoveryCodes(ctx context.Context, userID string, codes []*model.RecoveryCode) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	// Enable TOTP
+	now := time.Now()
+	result, err := tx.ExecContext(ctx,
+		`UPDATE user_totp SET enabled = 1, verified_at = ? WHERE user_id = ?`, now, userID,
+	)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return ErrNotFound
+	}
+
+	// Delete any existing recovery codes
+	if _, err := tx.ExecContext(ctx, `DELETE FROM user_recovery_codes WHERE user_id = ?`, userID); err != nil {
+		return err
+	}
+
+	// Insert new recovery codes
+	stmt, err := tx.PrepareContext(ctx, `INSERT INTO user_recovery_codes (id, user_id, code_hash, created_at) VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, code := range codes {
+		code.CreatedAt = now
+		if _, err := stmt.ExecContext(ctx, code.ID, code.UserID, code.CodeHash, code.CreatedAt); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}

--- a/internal/service/totp.go
+++ b/internal/service/totp.go
@@ -127,19 +127,15 @@ func (s *TOTPService) ConfirmSetup(ctx context.Context, userID, code string) ([]
 		return nil, ErrInvalidTOTPCode
 	}
 
-	// Enable 2FA
-	if err := s.totpRepo.Enable(ctx, userID); err != nil {
-		return nil, fmt.Errorf("failed to enable 2FA: %w", err)
-	}
-
 	// Generate recovery codes
 	codes, plainCodes, err := s.generateRecoveryCodes(userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate recovery codes: %w", err)
 	}
 
-	if err := s.totpRepo.SaveRecoveryCodes(ctx, codes); err != nil {
-		return nil, fmt.Errorf("failed to save recovery codes: %w", err)
+	// Atomically enable 2FA and save recovery codes
+	if err := s.totpRepo.EnableAndSaveRecoveryCodes(ctx, userID, codes); err != nil {
+		return nil, fmt.Errorf("failed to enable 2FA: %w", err)
 	}
 
 	return plainCodes, nil
@@ -361,31 +357,32 @@ func (s *TOTPService) encryptSecret(plaintext string) (string, error) {
 }
 
 // decryptSecret decrypts an AES-GCM encrypted TOTP secret.
-// If decryption fails, it returns the input as-is to handle legacy plaintext secrets.
+// If the input is not valid base64, it is treated as a legacy plaintext secret.
+// If base64 decoding succeeds but decryption fails, an error is returned
+// (indicating a corrupt ciphertext or wrong encryption key).
 func (s *TOTPService) decryptSecret(encoded string) (string, error) {
 	data, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		// Not base64 — likely a legacy plaintext secret
+		// Not base64 — legacy plaintext secret
 		return encoded, nil
 	}
 	key := deriveEncryptionKey(s.jwtSecret)
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return encoded, nil
+		return "", fmt.Errorf("failed to create cipher: %w", err)
 	}
 	gcm, err := cipher.NewGCM(block)
 	if err != nil {
-		return encoded, nil
+		return "", fmt.Errorf("failed to create GCM: %w", err)
 	}
 	nonceSize := gcm.NonceSize()
 	if len(data) < nonceSize {
-		// Too short to be encrypted — legacy plaintext
+		// Too short to be a valid ciphertext — legacy plaintext
 		return encoded, nil
 	}
 	plaintext, err := gcm.Open(nil, data[:nonceSize], data[nonceSize:], nil)
 	if err != nil {
-		// Decryption failed — likely a legacy plaintext secret
-		return encoded, nil
+		return "", fmt.Errorf("failed to decrypt TOTP secret (wrong key or corrupt data): %w", err)
 	}
 	return string(plaintext), nil
 }

--- a/internal/service/totp_test.go
+++ b/internal/service/totp_test.go
@@ -1,0 +1,518 @@
+package service_test
+
+import (
+	"context"
+	"encoding/base32"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+
+	"github.com/amalgamated-tools/enlace/internal/database"
+	"github.com/amalgamated-tools/enlace/internal/repository"
+	"github.com/amalgamated-tools/enlace/internal/service"
+)
+
+var testJWTSecret = []byte("test-secret-key-for-jwt-signing")
+
+func setupTOTPService(t *testing.T) (*service.TOTPService, *service.AuthService, func()) {
+	t.Helper()
+	db, err := database.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+
+	userRepo := repository.NewUserRepository(db.DB())
+	totpRepo := repository.NewTOTPRepository(db.DB())
+	authService := service.NewAuthService(userRepo, testJWTSecret)
+	totpService := service.NewTOTPService(totpRepo, userRepo, testJWTSecret)
+
+	return totpService, authService, func() { db.Close() }
+}
+
+func createTestUser(t *testing.T, authSvc *service.AuthService) string {
+	t.Helper()
+	ctx := context.Background()
+	user, err := authSvc.Register(ctx, "test@example.com", "password123", "Test User")
+	if err != nil {
+		t.Fatalf("failed to register test user: %v", err)
+	}
+	return user.ID
+}
+
+func setupAndConfirmTOTP(t *testing.T, svc *service.TOTPService, userID string) (secret string, recoveryCodes []string) {
+	t.Helper()
+	ctx := context.Background()
+
+	secret, _, _, err := svc.BeginSetup(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to begin TOTP setup: %v", err)
+	}
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate TOTP code: %v", err)
+	}
+
+	recoveryCodes, err = svc.ConfirmSetup(ctx, userID, code)
+	if err != nil {
+		t.Fatalf("failed to confirm TOTP setup: %v", err)
+	}
+
+	return secret, recoveryCodes
+}
+
+func TestTOTPService_BeginSetup(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	secret, qrCode, provisioningURI, err := svc.BeginSetup(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to begin TOTP setup: %v", err)
+	}
+
+	if secret == "" {
+		t.Error("expected secret to be non-empty")
+	}
+	if qrCode == "" {
+		t.Error("expected QR code to be non-empty")
+	}
+	if provisioningURI == "" {
+		t.Error("expected provisioning URI to be non-empty")
+	}
+}
+
+func TestTOTPService_BeginSetup_AlreadyEnabled(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	setupAndConfirmTOTP(t, svc, userID)
+
+	_, _, _, err := svc.BeginSetup(ctx, userID)
+	if !errors.Is(err, service.ErrTOTPAlreadyEnabled) {
+		t.Errorf("expected ErrTOTPAlreadyEnabled, got %v", err)
+	}
+}
+
+func TestTOTPService_ConfirmSetup(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	secret, _, _, err := svc.BeginSetup(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to begin TOTP setup: %v", err)
+	}
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate TOTP code: %v", err)
+	}
+
+	recoveryCodes, err := svc.ConfirmSetup(ctx, userID, code)
+	if err != nil {
+		t.Fatalf("failed to confirm TOTP setup: %v", err)
+	}
+
+	if len(recoveryCodes) != 10 {
+		t.Errorf("expected 10 recovery codes, got %d", len(recoveryCodes))
+	}
+
+	for i, rc := range recoveryCodes {
+		if !strings.Contains(rc, "-") {
+			t.Errorf("recovery code %d (%q) does not contain a dash", i, rc)
+		}
+	}
+}
+
+func TestTOTPService_ConfirmSetup_InvalidCode(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	_, _, _, err := svc.BeginSetup(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to begin TOTP setup: %v", err)
+	}
+
+	_, err = svc.ConfirmSetup(ctx, userID, "000000")
+	if !errors.Is(err, service.ErrInvalidTOTPCode) {
+		t.Errorf("expected ErrInvalidTOTPCode, got %v", err)
+	}
+}
+
+func TestTOTPService_ConfirmSetup_NotStarted(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	_, err := svc.ConfirmSetup(ctx, userID, "123456")
+	if !errors.Is(err, service.ErrTOTPNotSetup) {
+		t.Errorf("expected ErrTOTPNotSetup, got %v", err)
+	}
+}
+
+func TestTOTPService_Verify(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	secret, _ := setupAndConfirmTOTP(t, svc, userID)
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate TOTP code: %v", err)
+	}
+
+	err = svc.Verify(ctx, userID, code)
+	if err != nil {
+		t.Errorf("expected Verify to succeed, got %v", err)
+	}
+}
+
+func TestTOTPService_Verify_InvalidCode(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	setupAndConfirmTOTP(t, svc, userID)
+
+	err := svc.Verify(ctx, userID, "000000")
+	if !errors.Is(err, service.ErrInvalidTOTPCode) {
+		t.Errorf("expected ErrInvalidTOTPCode, got %v", err)
+	}
+}
+
+func TestTOTPService_Verify_NotEnabled(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	err := svc.Verify(ctx, userID, "123456")
+	if !errors.Is(err, service.ErrTOTPNotEnabled) {
+		t.Errorf("expected ErrTOTPNotEnabled, got %v", err)
+	}
+}
+
+func TestTOTPService_VerifyRecoveryCode(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	_, recoveryCodes := setupAndConfirmTOTP(t, svc, userID)
+
+	// Use the first recovery code
+	codeToUse := recoveryCodes[0]
+	err := svc.VerifyRecoveryCode(ctx, userID, codeToUse)
+	if err != nil {
+		t.Fatalf("expected first use of recovery code to succeed, got %v", err)
+	}
+
+	// Second use of the same code should fail (consumed)
+	err = svc.VerifyRecoveryCode(ctx, userID, codeToUse)
+	if !errors.Is(err, service.ErrInvalidRecoveryCode) {
+		t.Errorf("expected ErrInvalidRecoveryCode on second use, got %v", err)
+	}
+}
+
+func TestTOTPService_VerifyRecoveryCode_Invalid(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	setupAndConfirmTOTP(t, svc, userID)
+
+	err := svc.VerifyRecoveryCode(ctx, userID, "invalid-recovery-code")
+	if !errors.Is(err, service.ErrInvalidRecoveryCode) {
+		t.Errorf("expected ErrInvalidRecoveryCode, got %v", err)
+	}
+}
+
+func TestTOTPService_Disable(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	setupAndConfirmTOTP(t, svc, userID)
+
+	// Verify 2FA is enabled
+	enabled, err := svc.GetStatus(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to get status: %v", err)
+	}
+	if !enabled {
+		t.Fatal("expected 2FA to be enabled before disabling")
+	}
+
+	// Disable 2FA
+	err = svc.Disable(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to disable 2FA: %v", err)
+	}
+
+	// Verify 2FA is disabled
+	enabled, err = svc.GetStatus(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to get status after disable: %v", err)
+	}
+	if enabled {
+		t.Error("expected 2FA to be disabled after calling Disable")
+	}
+}
+
+func TestTOTPService_RegenerateRecoveryCodes(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	_, oldCodes := setupAndConfirmTOTP(t, svc, userID)
+
+	// Regenerate recovery codes
+	newCodes, err := svc.RegenerateRecoveryCodes(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to regenerate recovery codes: %v", err)
+	}
+
+	if len(newCodes) != 10 {
+		t.Errorf("expected 10 new recovery codes, got %d", len(newCodes))
+	}
+
+	// Old codes should no longer work
+	err = svc.VerifyRecoveryCode(ctx, userID, oldCodes[0])
+	if !errors.Is(err, service.ErrInvalidRecoveryCode) {
+		t.Errorf("expected old recovery code to be invalid after regeneration, got %v", err)
+	}
+
+	// New codes should work
+	err = svc.VerifyRecoveryCode(ctx, userID, newCodes[0])
+	if err != nil {
+		t.Errorf("expected new recovery code to be valid, got %v", err)
+	}
+}
+
+func TestTOTPService_RegenerateRecoveryCodes_NotEnabled(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	_, err := svc.RegenerateRecoveryCodes(ctx, userID)
+	if !errors.Is(err, service.ErrTOTPNotEnabled) {
+		t.Errorf("expected ErrTOTPNotEnabled, got %v", err)
+	}
+}
+
+func TestTOTPService_GetStatus(t *testing.T) {
+	svc, authSvc, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	userID := createTestUser(t, authSvc)
+
+	// Before setup, status should be false
+	enabled, err := svc.GetStatus(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to get status: %v", err)
+	}
+	if enabled {
+		t.Error("expected 2FA status to be false before setup")
+	}
+
+	// After setup and confirm, status should be true
+	setupAndConfirmTOTP(t, svc, userID)
+
+	enabled, err = svc.GetStatus(ctx, userID)
+	if err != nil {
+		t.Fatalf("failed to get status after setup: %v", err)
+	}
+	if !enabled {
+		t.Error("expected 2FA status to be true after setup and confirm")
+	}
+}
+
+func TestTOTPService_GeneratePendingToken(t *testing.T) {
+	svc, _, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	token, err := svc.GeneratePendingToken("user-123", false)
+	if err != nil {
+		t.Fatalf("failed to generate pending token: %v", err)
+	}
+
+	if token == "" {
+		t.Error("expected pending token to be non-empty")
+	}
+}
+
+func TestTOTPService_ValidatePendingToken(t *testing.T) {
+	svc, _, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	userID := "user-456"
+	isAdmin := true
+
+	token, err := svc.GeneratePendingToken(userID, isAdmin)
+	if err != nil {
+		t.Fatalf("failed to generate pending token: %v", err)
+	}
+
+	claims, err := svc.ValidatePendingToken(token)
+	if err != nil {
+		t.Fatalf("failed to validate pending token: %v", err)
+	}
+
+	if claims.UserID != userID {
+		t.Errorf("expected UserID %q, got %q", userID, claims.UserID)
+	}
+	if claims.IsAdmin != isAdmin {
+		t.Errorf("expected IsAdmin %v, got %v", isAdmin, claims.IsAdmin)
+	}
+	if !claims.TFA {
+		t.Error("expected TFA claim to be true")
+	}
+}
+
+func TestTOTPService_ValidatePendingToken_Invalid(t *testing.T) {
+	svc, _, cleanup := setupTOTPService(t)
+	defer cleanup()
+
+	_, err := svc.ValidatePendingToken("invalid-token-string")
+	if !errors.Is(err, service.ErrInvalidToken) {
+		t.Errorf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestTOTPService_EncryptDecrypt(t *testing.T) {
+	db, err := database.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	userRepo := repository.NewUserRepository(db.DB())
+	totpRepo := repository.NewTOTPRepository(db.DB())
+	authService := service.NewAuthService(userRepo, testJWTSecret)
+	totpService := service.NewTOTPService(totpRepo, userRepo, testJWTSecret)
+
+	ctx := context.Background()
+
+	user, err := authService.Register(ctx, "encrypt@example.com", "password123", "Encrypt User")
+	if err != nil {
+		t.Fatalf("failed to register user: %v", err)
+	}
+
+	// Begin setup to get the plaintext secret
+	secret, _, _, err := totpService.BeginSetup(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("failed to begin TOTP setup: %v", err)
+	}
+
+	// Read the stored secret directly from the DB
+	storedRecord, err := totpRepo.GetByUserID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("failed to get TOTP record from DB: %v", err)
+	}
+
+	// The stored secret should NOT be the same as the plaintext secret (it should be encrypted)
+	if storedRecord.Secret == secret {
+		t.Error("expected stored secret to be encrypted (different from plaintext secret)")
+	}
+
+	// Confirm the setup works (which proves decryption works internally)
+	code, err := totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate TOTP code: %v", err)
+	}
+
+	_, err = totpService.ConfirmSetup(ctx, user.ID, code)
+	if err != nil {
+		t.Fatalf("failed to confirm setup (decrypt should work): %v", err)
+	}
+
+	// Verify also works (which again uses decryption)
+	code, err = totp.GenerateCode(secret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate TOTP code for verify: %v", err)
+	}
+
+	err = totpService.Verify(ctx, user.ID, code)
+	if err != nil {
+		t.Errorf("expected Verify to succeed after encrypt/decrypt, got %v", err)
+	}
+}
+
+func TestTOTPService_DecryptLegacyPlaintext(t *testing.T) {
+	db, err := database.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	userRepo := repository.NewUserRepository(db.DB())
+	totpRepo := repository.NewTOTPRepository(db.DB())
+	authService := service.NewAuthService(userRepo, testJWTSecret)
+	totpService := service.NewTOTPService(totpRepo, userRepo, testJWTSecret)
+
+	ctx := context.Background()
+
+	user, err := authService.Register(ctx, "legacy@example.com", "password123", "Legacy User")
+	if err != nil {
+		t.Fatalf("failed to register user: %v", err)
+	}
+
+	// Create a plaintext TOTP secret that is NOT valid base64.
+	// The decryptSecret function treats non-base64 strings as legacy plaintext.
+	// Using a 6-byte raw value encoded as base32 without padding produces a
+	// 10-character string, which is not valid base64 (length not divisible by 4).
+	rawSecret := []byte("legacy")
+	plaintextSecret := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(rawSecret)
+
+	// Store the plaintext secret directly in the DB (simulating legacy data)
+	_, err = db.DB().ExecContext(ctx,
+		`INSERT INTO user_totp (user_id, secret, enabled, created_at) VALUES (?, ?, 1, ?)`,
+		user.ID, plaintextSecret, time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("failed to insert legacy TOTP record: %v", err)
+	}
+
+	// Verify with a valid TOTP code should work (decryptSecret falls back to plaintext)
+	code, err := totp.GenerateCode(plaintextSecret, time.Now())
+	if err != nil {
+		t.Fatalf("failed to generate TOTP code: %v", err)
+	}
+
+	err = totpService.Verify(ctx, user.ID, code)
+	if err != nil {
+		t.Errorf("expected Verify to succeed with legacy plaintext secret, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implement optional per-user TOTP-based 2FA with admin enforcement capability. Users can enable 2FA in settings using any TOTP authenticator app (Google Authenticator, Authy, 1Password, etc.). Admin can require 2FA globally via `REQUIRE_2FA` environment variable.

## Changes

**Backend:** TOTP models, repository, and service with full setup/verify/disable flow. Two-phase login returns 5-min pending JWT token when 2FA enabled, then verifies code at `/auth/2fa/verify`. Recovery codes (10 bcrypt-hashed codes, single-use). Middleware rejects pending tokens from accessing protected resources. Rate limited 2FA endpoints. Complete Swagger documentation.

**Frontend:** New TwoFactorVerify route for login flow. Settings page with 2FA management (enable with QR code, save recovery codes, regenerate, disable). Updated auth store and login flow to detect 2FA requirement and redirect appropriately.

## Test Plan

- Backend tests pass (all packages green)
- Go code formatted
- Frontend code formatted with Prettier
- Swagger docs regenerated with all 7 new 2FA endpoints
- No TypeScript errors in source files