### PR TITLE
Add copy and download buttons for 2FA recovery codes

### DIFF
--- a/frontend/src/routes/Settings.svelte
+++ b/frontend/src/routes/Settings.svelte
@@ -37,11 +37,16 @@
   let setupErrors: Record<string, string> = {};
   let codesCopied = false;
 
-  function copyRecoveryCodes() {
-    navigator.clipboard.writeText(setupRecoveryCodes.join("\n"));
-    toast.success("Recovery codes copied to clipboard");
-    codesCopied = true;
-    setTimeout(() => (codesCopied = false), 2000);
+  async function copyRecoveryCodes() {
+    try {
+      await navigator.clipboard.writeText(setupRecoveryCodes.join("\n"));
+      toast.success("Recovery codes copied to clipboard");
+      codesCopied = true;
+      setTimeout(() => (codesCopied = false), 2000);
+    } catch (error) {
+      console.error("Failed to copy recovery codes", error);
+      toast.error("Failed to copy recovery codes. Please copy them manually.");
+    }
   }
 
   function downloadRecoveryCodes() {
@@ -52,7 +57,7 @@
     a.href = url;
     a.download = "enlace-2fa.txt";
     a.click();
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 100);
   }
 
   onMount(async () => {


### PR DESCRIPTION
When users set up 2FA or regenerate recovery codes, the recovery codes modal now displays two additional action buttons alongside the Done button. The "Copy Codes" button copies all codes to the clipboard with a toast notification, and the "Download" button saves them to enlace-2fa.txt. This makes it easier for users to securely save their recovery codes.