### PR TITLE
Fix nav tab highlighting to reflect current URL

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -37,11 +37,11 @@
     $location.startsWith("/s/");
   $: showLayout = $auth.initialized && $isAuthenticated && !isPublicPage;
 
-  // Active nav link helper
-  function isActive(path: string): boolean {
-    if (path === "/") return $location === "/";
-    return $location.startsWith(path);
-  }
+  // Active nav link helpers (reactive so Svelte tracks $location dependency)
+  $: dashboardActive = $location === "/";
+  $: sharesActive = $location.startsWith("/shares");
+  $: settingsActive = $location.startsWith("/settings");
+  $: adminActive = $location.startsWith("/admin");
 </script>
 
 {#if !$auth.initialized}
@@ -83,9 +83,7 @@
           <nav class="flex items-center gap-1">
             <a
               href="#/"
-              class="px-3 py-1.5 text-sm rounded-md transition-colors {isActive(
-                '/',
-              )
+              class="px-3 py-1.5 text-sm rounded-md transition-colors {dashboardActive
                 ? 'text-text bg-surface-muted font-medium'
                 : 'text-muted hover:text-text hover:bg-surface-subtle'}"
             >
@@ -93,9 +91,7 @@
             </a>
             <a
               href="#/shares"
-              class="px-3 py-1.5 text-sm rounded-md transition-colors {isActive(
-                '/shares',
-              )
+              class="px-3 py-1.5 text-sm rounded-md transition-colors {sharesActive
                 ? 'text-text bg-surface-muted font-medium'
                 : 'text-muted hover:text-text hover:bg-surface-subtle'}"
             >
@@ -103,9 +99,7 @@
             </a>
             <a
               href="#/settings"
-              class="px-3 py-1.5 text-sm rounded-md transition-colors {isActive(
-                '/settings',
-              )
+              class="px-3 py-1.5 text-sm rounded-md transition-colors {settingsActive
                 ? 'text-text bg-surface-muted font-medium'
                 : 'text-muted hover:text-text hover:bg-surface-subtle'}"
             >
@@ -114,9 +108,7 @@
             {#if $auth.user?.is_admin}
               <a
                 href="#/admin/users"
-                class="px-3 py-1.5 text-sm rounded-md transition-colors {isActive(
-                  '/admin',
-                )
+                class="px-3 py-1.5 text-sm rounded-md transition-colors {adminActive
                   ? 'text-text bg-surface-muted font-medium'
                   : 'text-muted hover:text-text hover:bg-surface-subtle'}"
               >


### PR DESCRIPTION
## Summary

The navigation tab highlight was always stuck on Settings regardless of which page the user was viewing. The issue was in the `isActive()` function—Svelte's reactivity couldn't track the `$location` store dependency when accessed through a function call in template expressions. Replaced with reactive declarations so Svelte properly re-evaluates active states on navigation.

## Changes

- Replaced `isActive()` function with reactive declarations for each tab (`dashboardActive`, `sharesActive`, `settingsActive`, `adminActive`)
- Updated template expressions to use these reactive variables instead of function calls
- Simplifies code and fixes the reactivity bug

## Test Plan

- Navigate between Dashboard, Shares, Settings, and Admin tabs
- Verify the correct tab is highlighted based on the current URL
- Verify no console errors appear