### PR TITLE
Add S3 connection validation to storage admin page

### DIFF
--- a/frontend/src/routes/admin/Storage.svelte
+++ b/frontend/src/routes/admin/Storage.svelte
@@ -36,6 +36,9 @@
   let resetModal = false;
   let resetting = false;
 
+  // Test connection
+  let testing = false;
+
   $: hasOverrides = storageType !== "";
 
   $: if ($auth.initialized && !$isAuthenticated) {
@@ -178,6 +181,31 @@
       resetting = false;
     }
   }
+
+  async function handleTestConnection() {
+    testing = true;
+    try {
+      const payload: Record<string, string> = {};
+      payload.s3_bucket = s3Bucket.trim();
+      payload.s3_region = s3Region.trim();
+      payload.s3_path_prefix = s3PathPrefix.trim();
+      payload.s3_endpoint = s3Endpoint.trim();
+      if (s3AccessKey.trim()) {
+        payload.s3_access_key = s3AccessKey.trim();
+      }
+      if (s3SecretKey.trim()) {
+        payload.s3_secret_key = s3SecretKey.trim();
+      }
+      await api.post<void>("/admin/storage/test", payload);
+      toast.success("S3 connection successful");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "S3 connection test failed";
+      toast.error(message);
+    } finally {
+      testing = false;
+    }
+  }
 </script>
 
 <AdminNav />
@@ -290,9 +318,21 @@
         {/if}
 
         {#if storageType}
-          <Button type="submit" loading={saving}>
-            {saving ? "Saving..." : "Save Configuration"}
-          </Button>
+          <div class="flex items-center gap-3">
+            <Button type="submit" loading={saving}>
+              {saving ? "Saving..." : "Save Configuration"}
+            </Button>
+            {#if storageType === "s3"}
+              <Button
+                type="button"
+                variant="secondary"
+                loading={testing}
+                on:click={handleTestConnection}
+              >
+                {testing ? "Testing..." : "Test Connection"}
+              </Button>
+            {/if}
+          </div>
         {/if}
       </form>
     </div>

--- a/internal/handler/admin_storage.go
+++ b/internal/handler/admin_storage.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/amalgamated-tools/enlace/internal/crypto"
+	"github.com/amalgamated-tools/enlace/internal/storage"
 )
 
 // storageSettingKeys are the known storage-related setting keys.
@@ -269,4 +270,102 @@ func validateEffectiveStorageConfig(effective map[string]string) map[string]stri
 	}
 
 	return errs
+}
+
+// TestStorageConnection handles POST /api/v1/admin/storage/test - validates S3 connectivity.
+//
+//	@Summary		Test S3 connection
+//	@Description	Tests the S3 connection by performing a HeadBucket operation using the provided credentials merged with existing DB settings. Requires admin role.
+//	@Tags			admin
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			body	body		updateStorageConfigRequest	true	"S3 configuration fields to test (merged with existing DB settings)"
+//	@Success		200		{object}	APIResponse
+//	@Failure		400		{object}	ValidationErrorResponse
+//	@Failure		401		{object}	APIResponse
+//	@Failure		403		{object}	APIResponse
+//	@Failure		422		{object}	APIResponse
+//	@Failure		500		{object}	APIResponse
+//	@Router			/api/v1/admin/storage/test [post]
+func (h *StorageConfigHandler) TestStorageConnection(w http.ResponseWriter, r *http.Request) {
+	var req updateStorageConfigRequest
+	if err := DecodeJSON(r, &req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Build the effective configuration by merging existing DB settings with the request.
+	existing, err := h.settingsRepo.GetMultiple(r.Context(), storageSettingKeys)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to retrieve current storage settings")
+		return
+	}
+
+	effective := make(map[string]string)
+	for k, v := range existing {
+		effective[k] = v
+	}
+	if req.S3Endpoint != nil {
+		effective["s3_endpoint"] = strings.TrimSpace(*req.S3Endpoint)
+	}
+	if req.S3Bucket != nil {
+		effective["s3_bucket"] = strings.TrimSpace(*req.S3Bucket)
+	}
+	if req.S3AccessKey != nil {
+		effective["s3_access_key"] = strings.TrimSpace(*req.S3AccessKey)
+	}
+	if req.S3SecretKey != nil {
+		effective["s3_secret_key"] = strings.TrimSpace(*req.S3SecretKey)
+	}
+	if req.S3Region != nil {
+		effective["s3_region"] = strings.TrimSpace(*req.S3Region)
+	}
+	if req.S3PathPrefix != nil {
+		effective["s3_path_prefix"] = strings.TrimSpace(*req.S3PathPrefix)
+	}
+
+	// Validate required S3 fields are present.
+	errs := make(map[string]string)
+	if effective["s3_bucket"] == "" {
+		errs["s3_bucket"] = "required for connection test"
+	}
+	if effective["s3_access_key"] == "" {
+		errs["s3_access_key"] = "required for connection test"
+	}
+	if effective["s3_secret_key"] == "" {
+		errs["s3_secret_key"] = "required for connection test"
+	}
+	if len(errs) > 0 {
+		ValidationError(w, errs)
+		return
+	}
+
+	// Decrypt the secret key if it's stored encrypted in DB.
+	secretKey := effective["s3_secret_key"]
+	decrypted, err := crypto.Decrypt(secretKey, h.encryptionKey)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "failed to decrypt secret key")
+		return
+	}
+
+	s3Store, err := storage.NewS3Storage(r.Context(), storage.S3Config{
+		Endpoint:   effective["s3_endpoint"],
+		Bucket:     effective["s3_bucket"],
+		AccessKey:  effective["s3_access_key"],
+		SecretKey:  decrypted,
+		Region:     effective["s3_region"],
+		PathPrefix: effective["s3_path_prefix"],
+	})
+	if err != nil {
+		Error(w, http.StatusUnprocessableEntity, "failed to initialize S3 client: "+err.Error())
+		return
+	}
+
+	if err := s3Store.ValidateConnection(r.Context()); err != nil {
+		Error(w, http.StatusUnprocessableEntity, "S3 connection failed: "+err.Error())
+		return
+	}
+
+	Success(w, http.StatusOK, nil)
 }

--- a/internal/handler/admin_storage_test.go
+++ b/internal/handler/admin_storage_test.go
@@ -68,6 +68,7 @@ func setupStorageRouter(h *handler.StorageConfigHandler) *chi.Mux {
 		r.Get("/", h.GetStorageConfig)
 		r.Put("/", h.UpdateStorageConfig)
 		r.Delete("/", h.DeleteStorageConfig)
+		r.Post("/test", h.TestStorageConnection)
 	})
 	return r
 }
@@ -591,5 +592,160 @@ func TestStorageConfigHandler_DeleteStorageConfig_DatabaseError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+// --- TestStorageConnection Tests ---
+
+func TestStorageConfigHandler_TestStorageConnection_MissingFields(t *testing.T) {
+	mock := &mockSettingsRepository{
+		getMultipleFn: func(ctx context.Context, keys []string) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	}
+
+	h := handler.NewStorageConfigHandler(mock, storageTestJWTSecret)
+	router := setupStorageRouter(h)
+
+	body := `{}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/storage/test", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAdminRequestContext(req)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d: %s", http.StatusBadRequest, w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Success bool              `json:"success"`
+		Fields  map[string]string `json:"fields"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+	if _, ok := response.Fields["s3_bucket"]; !ok {
+		t.Error("expected field error for s3_bucket")
+	}
+	if _, ok := response.Fields["s3_access_key"]; !ok {
+		t.Error("expected field error for s3_access_key")
+	}
+	if _, ok := response.Fields["s3_secret_key"]; !ok {
+		t.Error("expected field error for s3_secret_key")
+	}
+}
+
+func TestStorageConfigHandler_TestStorageConnection_InvalidJSON(t *testing.T) {
+	mock := &mockSettingsRepository{}
+
+	h := handler.NewStorageConfigHandler(mock, storageTestJWTSecret)
+	router := setupStorageRouter(h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/storage/test", bytes.NewBufferString(`{invalid`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAdminRequestContext(req)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func TestStorageConfigHandler_TestStorageConnection_DatabaseError(t *testing.T) {
+	mock := &mockSettingsRepository{
+		getMultipleFn: func(ctx context.Context, keys []string) (map[string]string, error) {
+			return nil, errors.New("database error")
+		},
+	}
+
+	h := handler.NewStorageConfigHandler(mock, storageTestJWTSecret)
+	router := setupStorageRouter(h)
+
+	body := `{"s3_bucket": "test-bucket", "s3_access_key": "AKIA123", "s3_secret_key": "secret"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/storage/test", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAdminRequestContext(req)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d, got %d: %s", http.StatusInternalServerError, w.Code, w.Body.String())
+	}
+}
+
+func TestStorageConfigHandler_TestStorageConnection_MergesDBSettings(t *testing.T) {
+	// DB has access_key and secret_key already; request only provides bucket
+	mock := &mockSettingsRepository{
+		getMultipleFn: func(ctx context.Context, keys []string) (map[string]string, error) {
+			return map[string]string{
+				"s3_access_key": "AKIA_FROM_DB",
+				"s3_secret_key": "plaintext-secret", // unencrypted legacy value
+			}, nil
+		},
+	}
+
+	h := handler.NewStorageConfigHandler(mock, storageTestJWTSecret)
+	router := setupStorageRouter(h)
+
+	// Only provide bucket — access_key and secret_key come from DB
+	body := `{"s3_bucket": "test-bucket", "s3_endpoint": "http://localhost:19000"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/storage/test", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAdminRequestContext(req)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// We expect 422 (connection failed to fake endpoint) rather than 400 (missing fields),
+	// proving the merge worked.
+	if w.Code == http.StatusBadRequest {
+		t.Errorf("expected merge to fill missing fields, but got 400: %s", w.Body.String())
+	}
+}
+
+func TestStorageConfigHandler_TestStorageConnection_InvalidEndpoint(t *testing.T) {
+	mock := &mockSettingsRepository{
+		getMultipleFn: func(ctx context.Context, keys []string) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+	}
+
+	h := handler.NewStorageConfigHandler(mock, storageTestJWTSecret)
+	router := setupStorageRouter(h)
+
+	body := `{"s3_bucket": "test-bucket", "s3_access_key": "AKIA123", "s3_secret_key": "secret", "s3_endpoint": "http://localhost:19000"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/storage/test", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withAdminRequestContext(req)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	// Should get 422 because connection to fake endpoint fails
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected status %d, got %d: %s", http.StatusUnprocessableEntity, w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Success bool   `json:"success"`
+		Error   string `json:"error"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Success {
+		t.Error("expected success to be false")
+	}
+	if !strings.Contains(response.Error, "S3 connection failed") {
+		t.Errorf("expected error to mention S3 connection failure, got %q", response.Error)
 	}
 }

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -234,6 +234,7 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 					r.Get("/", storageConfigHandler.GetStorageConfig)
 					r.Put("/", storageConfigHandler.UpdateStorageConfig)
 					r.Delete("/", storageConfigHandler.DeleteStorageConfig)
+					r.Post("/test", storageConfigHandler.TestStorageConnection)
 				})
 			}
 			if fileRestrictionsHandler != nil {

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -177,6 +177,15 @@ func (s *S3Storage) Exists(ctx context.Context, key string) (bool, error) {
 	return true, nil
 }
 
+// ValidateConnection checks that the S3 credentials and bucket are valid
+// by performing a HeadBucket operation.
+func (s *S3Storage) ValidateConnection(ctx context.Context) error {
+	_, err := s.client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(s.bucket),
+	})
+	return err
+}
+
 // isNotFoundError checks if the error indicates a missing object.
 func isNotFoundError(err error) bool {
 	var noSuchKey *types.NoSuchKey


### PR DESCRIPTION
## Summary

Adds validation of S3 credentials and bucket access in the storage admin configuration page. Admins can now test their S3 connection before saving the configuration by clicking a "Test Connection" button.

- New `POST /api/v1/admin/storage/test` endpoint that performs a HeadBucket operation to validate credentials
- Merges form input with existing database settings to support testing with partially-saved credentials
- Frontend "Test Connection" button appears only when S3 storage type is selected
- Comprehensive error handling and reporting of connection failures

## Test plan

- Test connection with valid AWS S3 credentials
- Test connection with invalid bucket name (should fail with descriptive error)
- Test connection with invalid access key (should fail gracefully)
- Verify credentials already saved in DB are used when form fields are empty
- Confirm "Test Connection" button is only shown for S3 storage type