### PR TITLE
Auto-admin first user when database is empty

### DIFF
--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -32,7 +32,12 @@ func TestRequireAuth_ValidToken(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Register and login to get a valid token
+	// Register a first user (auto-admin) and then a non-admin user for testing
+	_, err := authService.Register(ctx, "admin@example.com", "password123", "Admin User")
+	if err != nil {
+		t.Fatalf("failed to register admin user: %v", err)
+	}
+
 	user, err := authService.Register(ctx, "test@example.com", "password123", "Test User")
 	if err != nil {
 		t.Fatalf("failed to register user: %v", err)
@@ -345,8 +350,14 @@ func TestRequireAuthAndRequireAdmin_ChainedMiddleware(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Register user
-	_, err := authService.Register(ctx, "test@example.com", "password123", "Test User")
+	// Register a first user (auto-admin) then a non-admin user for testing
+	_, err := authService.Register(ctx, "admin@example.com", "password123", "Admin User")
+	if err != nil {
+		t.Fatalf("failed to register admin user: %v", err)
+	}
+
+	// Register non-admin user
+	_, err = authService.Register(ctx, "test@example.com", "password123", "Test User")
 	if err != nil {
 		t.Fatalf("failed to register user: %v", err)
 	}

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -134,6 +134,13 @@ func (r *UserRepository) List(ctx context.Context) ([]*model.User, error) {
 	return users, rows.Err()
 }
 
+// Count returns the total number of users in the database.
+func (r *UserRepository) Count(ctx context.Context) (int, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&count)
+	return count, err
+}
+
 // EmailExists checks if a user with the given email address already exists.
 func (r *UserRepository) EmailExists(ctx context.Context, email string) (bool, error) {
 	var count int

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -279,6 +279,57 @@ func TestUserRepository_EmailExists(t *testing.T) {
 	}
 }
 
+func TestUserRepository_Count(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	repo := repository.NewUserRepository(db.DB())
+	ctx := context.Background()
+
+	// Empty database should return 0
+	count, err := repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("failed to count users: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 users, got %d", count)
+	}
+
+	// After creating a user, count should be 1
+	user := &model.User{
+		ID:           "user-123",
+		Email:        "test@example.com",
+		PasswordHash: "hashed",
+		DisplayName:  "Test User",
+	}
+	_ = repo.Create(ctx, user)
+
+	count, err = repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("failed to count users: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 user, got %d", count)
+	}
+
+	// After creating another user, count should be 2
+	user2 := &model.User{
+		ID:           "user-456",
+		Email:        "test2@example.com",
+		PasswordHash: "hashed",
+		DisplayName:  "Test User 2",
+	}
+	_ = repo.Create(ctx, user2)
+
+	count, err = repo.Count(ctx)
+	if err != nil {
+		t.Fatalf("failed to count users: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 users, got %d", count)
+	}
+}
+
 func TestUserRepository_GetByOIDC(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -82,12 +82,18 @@ func (s *AuthService) Register(ctx context.Context, email, password, displayName
 		return nil, err
 	}
 
+	// Auto-admin: first user in the database becomes admin
+	count, err := s.userRepo.Count(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	user := &model.User{
 		ID:           uuid.NewString(),
 		Email:        email,
 		PasswordHash: string(passwordHash),
 		DisplayName:  displayName,
-		IsAdmin:      false,
+		IsAdmin:      count == 0,
 	}
 
 	if err := s.userRepo.Create(ctx, user); err != nil {

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -56,6 +56,31 @@ func TestAuthService_Register(t *testing.T) {
 	}
 }
 
+func TestAuthService_Register_FirstUserIsAdmin(t *testing.T) {
+	svc, cleanup := setupAuthService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// First user should be admin
+	first, err := svc.Register(ctx, "first@example.com", "password123", "First User")
+	if err != nil {
+		t.Fatalf("failed to register first user: %v", err)
+	}
+	if !first.IsAdmin {
+		t.Error("expected first user to be admin")
+	}
+
+	// Second user should not be admin
+	second, err := svc.Register(ctx, "second@example.com", "password123", "Second User")
+	if err != nil {
+		t.Fatalf("failed to register second user: %v", err)
+	}
+	if second.IsAdmin {
+		t.Error("expected second user to not be admin")
+	}
+}
+
 func TestAuthService_Register_DuplicateEmail(t *testing.T) {
 	svc, cleanup := setupAuthService(t)
 	defer cleanup()
@@ -516,7 +541,12 @@ func TestAuthService_TokenClaimsContainAdminStatus(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Register a regular user
+	// Register a regular user (register a dummy first so this one isn't auto-admin)
+	_, err = svc.Register(ctx, "first@example.com", "password123", "First User")
+	if err != nil {
+		t.Fatalf("failed to register first user: %v", err)
+	}
+
 	user, err := svc.Register(ctx, "test@example.com", "password123", "Test User")
 	if err != nil {
 		t.Fatalf("failed to register user: %v", err)

--- a/internal/service/oidc.go
+++ b/internal/service/oidc.go
@@ -215,10 +215,17 @@ func (s *OIDCService) FindOrCreateUser(ctx context.Context, info *OIDCUserInfo) 
 	}
 
 	// Create new user
+	// Auto-admin: first user in the database becomes admin
+	count, err := s.userRepo.Count(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	newUser := &model.User{
 		ID:          uuid.NewString(),
 		Email:       info.Email,
 		DisplayName: info.DisplayName,
+		IsAdmin:     count == 0,
 		OIDCSubject: info.Subject,
 		OIDCIssuer:  info.Issuer,
 	}

--- a/internal/service/oidc_test.go
+++ b/internal/service/oidc_test.go
@@ -170,6 +170,46 @@ func TestOIDCService_FindOrCreateUser_NewUser(t *testing.T) {
 	}
 }
 
+func TestOIDCService_FindOrCreateUser_FirstUserIsAdmin(t *testing.T) {
+	db, err := database.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	defer db.Close()
+
+	userRepo := repository.NewUserRepository(db.DB())
+	svc := service.NewOIDCServiceForTest(userRepo, "https://issuer.example.com", nil)
+	ctx := context.Background()
+
+	// First OIDC user should be admin
+	first, err := svc.FindOrCreateUser(ctx, &service.OIDCUserInfo{
+		Subject:     "sub-first",
+		Email:       "first@example.com",
+		DisplayName: "First User",
+		Issuer:      "https://issuer.example.com",
+	})
+	if err != nil {
+		t.Fatalf("FindOrCreateUser failed: %v", err)
+	}
+	if !first.IsAdmin {
+		t.Error("expected first OIDC user to be admin")
+	}
+
+	// Second OIDC user should not be admin
+	second, err := svc.FindOrCreateUser(ctx, &service.OIDCUserInfo{
+		Subject:     "sub-second",
+		Email:       "second@example.com",
+		DisplayName: "Second User",
+		Issuer:      "https://issuer.example.com",
+	})
+	if err != nil {
+		t.Fatalf("FindOrCreateUser failed: %v", err)
+	}
+	if second.IsAdmin {
+		t.Error("expected second OIDC user to not be admin")
+	}
+}
+
 func TestOIDCService_UnlinkOIDC_RequiresPassword(t *testing.T) {
 	db, err := database.New(":memory:")
 	if err != nil {


### PR DESCRIPTION
## Summary
When a fresh Enlace instance is set up, the first user to register automatically becomes an admin. Subsequent users are created with standard permissions. This prevents the scenario where no admin exists to grant permissions to the first user.

## Changes
- Add `Count()` method to `UserRepository` to query the total number of users
- Update `AuthService.Register()` to check if the database is empty and set `IsAdmin: true` for the first user
- Update `OIDCService.FindOrCreateUser()` to apply the same logic for OIDC-based user creation
- Update affected tests to account for the new auto-admin behavior

## Test Plan
- All unit tests pass including new tests verifying first user gets admin and subsequent users don't
- Verified middleware tests handle both admin and non-admin user scenarios correctly