### PR TITLE
Add signed URL direct transfer for object storage (#108)

### DIFF
--- a/cmd/enlace/main.go
+++ b/cmd/enlace/main.go
@@ -104,7 +104,9 @@ func realMain(cancelCtx context.Context) error { //nolint:contextcheck // The ne
 	jwtSecret := []byte(cfg.JWTSecret)
 	authService := service.NewAuthService(userRepo, jwtSecret)
 	shareService := service.NewShareService(shareRepo, fileRepo, store)
-	fileService := service.NewFileService(fileRepo, shareRepo, store)
+	pendingUploadRepo := repository.NewPendingUploadRepository(db.DB())
+	presignExpiry := time.Duration(cfg.DirectTransferExpiry) * time.Second
+	fileService := service.NewFileService(fileRepo, shareRepo, store, pendingUploadRepo, presignExpiry)
 
 	// Initialize recipient repository and email service
 	recipientRepo := repository.NewRecipientRepository(db.DB())

--- a/frontend/src/lib/api/__tests__/files.test.ts
+++ b/frontend/src/lib/api/__tests__/files.test.ts
@@ -64,6 +64,134 @@ describe("filesApi", () => {
     });
   });
 
+  describe("directUploadInit", () => {
+    it("sends init request with file metadata", async () => {
+      const initData = {
+        upload_id: "up-1",
+        upload_url: "https://s3.example.com/presigned",
+        file_id: "f-1",
+        method: "PUT",
+        expires_at: "2024-01-01T00:10:00Z",
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: initData }),
+      });
+
+      const result = await filesApi.directUploadInit(
+        "share-1",
+        "test.txt",
+        100,
+        "text/plain",
+      );
+      expect(result).toEqual(initData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/shares/share-1/files/direct/init",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  describe("directUploadFinalize", () => {
+    it("sends finalize request with upload ID", async () => {
+      const fileData = {
+        id: "f-1",
+        name: "test.txt",
+        size: 100,
+        mime_type: "text/plain",
+        created_at: "2024-01-01",
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: fileData }),
+      });
+
+      const result = await filesApi.directUploadFinalize("share-1", "up-1");
+      expect(result).toEqual(fileData);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/shares/share-1/files/direct/finalize",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  describe("uploadWithDirectTransfer", () => {
+    it("uses direct upload when supported", async () => {
+      const initData = {
+        upload_id: "up-1",
+        upload_url: "https://s3.example.com/presigned",
+        file_id: "f-1",
+        method: "PUT",
+        expires_at: "2024-01-01T00:10:00Z",
+      };
+      const fileData = {
+        id: "f-1",
+        name: "test.txt",
+        size: 5,
+        mime_type: "text/plain",
+        created_at: "2024-01-01",
+      };
+
+      // init call
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: initData }),
+      });
+      // PUT to presigned URL
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      // finalize call
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: fileData }),
+      });
+
+      const file = new File(["hello"], "test.txt", { type: "text/plain" });
+      const result = await filesApi.uploadWithDirectTransfer("share-1", [file]);
+
+      expect(result).toEqual([fileData]);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      // Verify PUT to presigned URL
+      expect(mockFetch.mock.calls[1][0]).toBe(
+        "https://s3.example.com/presigned",
+      );
+      expect(mockFetch.mock.calls[1][1].method).toBe("PUT");
+    });
+
+    it("falls back to proxy upload on 409", async () => {
+      // init returns 409 (direct transfer unsupported)
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: () =>
+          Promise.resolve({
+            success: false,
+            error: "Direct transfer not supported",
+          }),
+      });
+      // fallback proxy upload
+      const fileData = [
+        {
+          id: "f-1",
+          name: "test.txt",
+          size: 5,
+          mime_type: "text/plain",
+          created_at: "2024-01-01",
+        },
+      ];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: fileData }),
+      });
+
+      const file = new File(["hello"], "test.txt", { type: "text/plain" });
+      const result = await filesApi.uploadWithDirectTransfer("share-1", [file]);
+
+      expect(result).toEqual(fileData);
+      // Second call should be the proxy upload to /api/v1/shares/share-1/files
+      expect(mockFetch.mock.calls[1][0]).toBe("/api/v1/shares/share-1/files");
+    });
+  });
+
   describe("delete", () => {
     it("sends DELETE request", async () => {
       mockFetch.mockResolvedValueOnce({

--- a/frontend/src/lib/api/files.ts
+++ b/frontend/src/lib/api/files.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "./client";
+import { api, ApiError } from "./client";
 
 export interface FileInfo {
   id: string;
@@ -6,6 +6,14 @@ export interface FileInfo {
   size: number;
   mime_type: string;
   created_at: string;
+}
+
+interface DirectUploadInitResponse {
+  upload_id: string;
+  upload_url: string;
+  file_id: string;
+  method: string;
+  expires_at: string;
 }
 
 export const filesApi = {
@@ -38,5 +46,71 @@ export const filesApi = {
     if (!response.ok || !data.success) {
       throw new ApiError(data.error || "Delete failed", response.status);
     }
+  },
+
+  directUploadInit: async (
+    shareId: string,
+    filename: string,
+    size: number,
+    contentType: string,
+  ): Promise<DirectUploadInitResponse> => {
+    return api.post<DirectUploadInitResponse>(
+      `/shares/${shareId}/files/direct/init`,
+      { filename, size, content_type: contentType },
+    );
+  },
+
+  directUploadFinalize: async (
+    shareId: string,
+    uploadId: string,
+  ): Promise<FileInfo> => {
+    return api.post<FileInfo>(`/shares/${shareId}/files/direct/finalize`, {
+      upload_id: uploadId,
+    });
+  },
+
+  uploadWithDirectTransfer: async (
+    shareId: string,
+    files: File[],
+  ): Promise<FileInfo[]> => {
+    const results: FileInfo[] = [];
+
+    for (const file of files) {
+      try {
+        // Attempt direct upload
+        const init = await filesApi.directUploadInit(
+          shareId,
+          file.name,
+          file.size,
+          file.type || "application/octet-stream",
+        );
+
+        // Upload directly to storage
+        const uploadResp = await fetch(init.upload_url, {
+          method: init.method,
+          headers: { "Content-Type": file.type || "application/octet-stream" },
+          body: file,
+        });
+
+        if (!uploadResp.ok) {
+          throw new Error("Direct upload to storage failed");
+        }
+
+        // Finalize
+        const fileInfo = await filesApi.directUploadFinalize(
+          shareId,
+          init.upload_id,
+        );
+        results.push(fileInfo);
+      } catch (err) {
+        // If direct transfer is unsupported (409) or fails, fall back to proxy upload
+        if (err instanceof ApiError && err.status === 409) {
+          return filesApi.upload(shareId, files);
+        }
+        throw err;
+      }
+    }
+
+    return results;
   },
 };

--- a/frontend/src/routes/NewShare.svelte
+++ b/frontend/src/routes/NewShare.svelte
@@ -66,7 +66,7 @@
       });
 
       if (pendingFiles.length > 0) {
-        await filesApi.upload(share.id, pendingFiles);
+        await filesApi.uploadWithDirectTransfer(share.id, pendingFiles);
       }
 
       toast.success("Share created successfully");

--- a/frontend/src/routes/PublicShare.svelte
+++ b/frontend/src/routes/PublicShare.svelte
@@ -93,27 +93,95 @@
 
     uploading = true;
     try {
-      const formData = new FormData();
-      event.detail.forEach((file) => formData.append("files", file));
-
-      const response = await fetch(`/s/${params.slug}/upload`, {
-        method: "POST",
-        body: formData,
-      });
-      const data = await response.json();
-
-      if (!response.ok || !data.success) {
-        toast.error(data.error || "Upload failed");
-        return;
-      }
-
-      files = [...files, ...data.data];
+      // Try direct upload first
+      const uploadedFiles = await directUploadToReverseShare(
+        params.slug,
+        event.detail,
+      );
+      files = [...files, ...uploadedFiles];
       toast.success(`${event.detail.length} file(s) uploaded`);
     } catch {
       toast.error("Upload failed");
     } finally {
       uploading = false;
     }
+  }
+
+  async function directUploadToReverseShare(
+    slug: string,
+    filesToUpload: File[],
+  ): Promise<any[]> {
+    const results: any[] = [];
+
+    for (const file of filesToUpload) {
+      try {
+        const initResp = await fetch(`/s/${slug}/upload/direct/init`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            filename: file.name,
+            size: file.size,
+            content_type: file.type || "application/octet-stream",
+          }),
+        });
+        const initData = await initResp.json();
+
+        if (initResp.status === 409 || !initResp.ok || !initData.success) {
+          // Fallback to proxy upload for all files
+          return proxyUploadToReverseShare(slug, filesToUpload);
+        }
+
+        // Upload directly to storage
+        const uploadResp = await fetch(initData.data.upload_url, {
+          method: initData.data.method,
+          headers: { "Content-Type": file.type || "application/octet-stream" },
+          body: file,
+        });
+
+        if (!uploadResp.ok) {
+          throw new Error("Direct upload to storage failed");
+        }
+
+        // Finalize
+        const finalizeResp = await fetch(`/s/${slug}/upload/direct/finalize`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ upload_id: initData.data.upload_id }),
+        });
+        const finalizeData = await finalizeResp.json();
+
+        if (!finalizeResp.ok || !finalizeData.success) {
+          throw new Error(finalizeData.error || "Finalize failed");
+        }
+
+        results.push(finalizeData.data);
+      } catch {
+        // On any failure, fall back to proxy upload for remaining files
+        return proxyUploadToReverseShare(slug, filesToUpload);
+      }
+    }
+
+    return results;
+  }
+
+  async function proxyUploadToReverseShare(
+    slug: string,
+    filesToUpload: File[],
+  ): Promise<any[]> {
+    const formData = new FormData();
+    filesToUpload.forEach((file) => formData.append("files", file));
+
+    const response = await fetch(`/s/${slug}/upload`, {
+      method: "POST",
+      body: formData,
+    });
+    const data = await response.json();
+
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || "Upload failed");
+    }
+
+    return data.data;
   }
 
   async function downloadAll() {
@@ -125,6 +193,17 @@
   }
 
   async function downloadFile(fileId: string) {
+    // Try direct download first (302 redirect from server), fall back to proxy
+    const directUrl = `/s/${params.slug}/files/${fileId}/direct`;
+    try {
+      const resp = await fetch(directUrl, { method: "HEAD" });
+      if (resp.ok || resp.status === 302) {
+        window.location.href = directUrl;
+        return;
+      }
+    } catch {
+      // ignore and fall back
+    }
     window.location.href = `/s/${params.slug}/files/${fileId}`;
   }
 

--- a/frontend/src/routes/ShareDetail.svelte
+++ b/frontend/src/routes/ShareDetail.svelte
@@ -129,7 +129,10 @@
 
     uploading = true;
     try {
-      const newFiles = await filesApi.upload(share.id, event.detail);
+      const newFiles = await filesApi.uploadWithDirectTransfer(
+        share.id,
+        event.detail,
+      );
       files = [...files, ...newFiles];
       toast.success(`${event.detail.length} file(s) uploaded`);
     } catch (err) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,38 +51,41 @@ type Config struct {
 	// Trusted reverse-proxy CIDRs whose X-Forwarded-For / X-Real-IP headers
 	// are trusted for client-IP extraction (e.g. rate limiting).
 	TrustedProxyCIDRs []string
+	// Direct transfer presigned URL expiry in seconds.
+	DirectTransferExpiry int
 }
 
 // Load reads environment-backed settings and returns the application config.
 func Load() *Config {
 	return &Config{
-		Port:              getEnvInt("PORT", 8080),
-		DatabasePath:      getEnv("DATABASE_PATH", "./enlace.db"),
-		JWTSecret:         loadJWTSecret(),
-		BaseURL:           getEnv("BASE_URL", "http://localhost:8080"),
-		StorageType:       getEnv("STORAGE_TYPE", "local"),
-		StorageLocalPath:  getEnv("STORAGE_LOCAL_PATH", "./uploads"),
-		S3Endpoint:        getEnv("S3_ENDPOINT", ""),
-		S3Bucket:          getEnv("S3_BUCKET", ""),
-		S3AccessKey:       getEnv("S3_ACCESS_KEY", ""),
-		S3SecretKey:       getEnv("S3_SECRET_KEY", ""),
-		S3Region:          getEnv("S3_REGION", ""),
-		S3PathPrefix:      getEnv("S3_PATH_PREFIX", ""),
-		SMTPHost:          getEnv("SMTP_HOST", ""),
-		SMTPPort:          getEnvInt("SMTP_PORT", 587),
-		SMTPUser:          getEnv("SMTP_USER", ""),
-		SMTPPass:          getEnv("SMTP_PASS", ""),
-		SMTPFrom:          getEnv("SMTP_FROM", "noreply@example.com"),
-		SMTPTLSPolicy:     getEnv("SMTP_TLS_POLICY", "opportunistic"),
-		OIDCEnabled:       getEnvBool("OIDC_ENABLED", false),
-		OIDCIssuerURL:     getEnv("OIDC_ISSUER_URL", ""),
-		OIDCClientID:      getEnv("OIDC_CLIENT_ID", ""),
-		OIDCClientSecret:  getEnv("OIDC_CLIENT_SECRET", ""),
-		OIDCRedirectURL:   getEnv("OIDC_REDIRECT_URL", ""),
-		OIDCScopes:        getEnv("OIDC_SCOPES", "openid email profile"),
-		CORSOrigins:       getEnv("CORS_ORIGINS", ""),
-		Require2FA:        getEnvBool("REQUIRE_2FA", false),
-		TrustedProxyCIDRs: getEnvStringSlice("TRUSTED_PROXIES", ","),
+		Port:                 getEnvInt("PORT", 8080),
+		DatabasePath:         getEnv("DATABASE_PATH", "./enlace.db"),
+		JWTSecret:            loadJWTSecret(),
+		BaseURL:              getEnv("BASE_URL", "http://localhost:8080"),
+		StorageType:          getEnv("STORAGE_TYPE", "local"),
+		StorageLocalPath:     getEnv("STORAGE_LOCAL_PATH", "./uploads"),
+		S3Endpoint:           getEnv("S3_ENDPOINT", ""),
+		S3Bucket:             getEnv("S3_BUCKET", ""),
+		S3AccessKey:          getEnv("S3_ACCESS_KEY", ""),
+		S3SecretKey:          getEnv("S3_SECRET_KEY", ""),
+		S3Region:             getEnv("S3_REGION", ""),
+		S3PathPrefix:         getEnv("S3_PATH_PREFIX", ""),
+		SMTPHost:             getEnv("SMTP_HOST", ""),
+		SMTPPort:             getEnvInt("SMTP_PORT", 587),
+		SMTPUser:             getEnv("SMTP_USER", ""),
+		SMTPPass:             getEnv("SMTP_PASS", ""),
+		SMTPFrom:             getEnv("SMTP_FROM", "noreply@example.com"),
+		SMTPTLSPolicy:        getEnv("SMTP_TLS_POLICY", "opportunistic"),
+		OIDCEnabled:          getEnvBool("OIDC_ENABLED", false),
+		OIDCIssuerURL:        getEnv("OIDC_ISSUER_URL", ""),
+		OIDCClientID:         getEnv("OIDC_CLIENT_ID", ""),
+		OIDCClientSecret:     getEnv("OIDC_CLIENT_SECRET", ""),
+		OIDCRedirectURL:      getEnv("OIDC_REDIRECT_URL", ""),
+		OIDCScopes:           getEnv("OIDC_SCOPES", "openid email profile"),
+		CORSOrigins:          getEnv("CORS_ORIGINS", ""),
+		Require2FA:           getEnvBool("REQUIRE_2FA", false),
+		TrustedProxyCIDRs:    getEnvStringSlice("TRUSTED_PROXIES", ","),
+		DirectTransferExpiry: getEnvInt("DIRECT_TRANSFER_EXPIRY_SECONDS", 600),
 	}
 }
 
@@ -116,6 +119,7 @@ func (c *Config) LogValue() slog.Value {
 		slog.String("oidc_scopes", c.OIDCScopes),
 		slog.String("cors_origins", c.CORSOrigins),
 		slog.Bool("require_2fa", c.Require2FA),
+		slog.Int("direct_transfer_expiry", c.DirectTransferExpiry),
 	)
 }
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -184,6 +184,21 @@ func runMigrations(db *sql.DB) error {
 			value TEXT NOT NULL,
 			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 		)`,
+		`CREATE TABLE IF NOT EXISTS pending_uploads (
+			id TEXT PRIMARY KEY,
+			file_id TEXT NOT NULL,
+			share_id TEXT NOT NULL,
+			uploader_id TEXT,
+			filename TEXT NOT NULL,
+			size INTEGER NOT NULL,
+			mime_type TEXT NOT NULL,
+			storage_key TEXT NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			expires_at DATETIME NOT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			finalized_at DATETIME
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_pending_uploads_status_expires ON pending_uploads(status, expires_at)`,
 	}
 
 	for _, m := range migrations {

--- a/internal/handler/file.go
+++ b/internal/handler/file.go
@@ -36,6 +36,8 @@ type FileHandlerFileService interface {
 	GetByID(ctx context.Context, id string) (*model.File, error)
 	Delete(ctx context.Context, id string) error
 	ListByShare(ctx context.Context, shareID string) ([]*model.File, error)
+	InitiateDirectUpload(ctx context.Context, input service.DirectUploadInput) (*service.DirectUploadResponse, error)
+	FinalizeDirectUpload(ctx context.Context, uploadID string) (*model.File, error)
 }
 
 // FileHandler handles file-related HTTP requests.
@@ -369,4 +371,234 @@ func (h *FileHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	Success(w, http.StatusOK, nil)
+}
+
+// directUploadInitRequest is the JSON body for direct upload initiation.
+type directUploadInitRequest struct {
+	Filename    string `json:"filename"`
+	Size        int64  `json:"size"`
+	ContentType string `json:"content_type"`
+}
+
+// InitiateDirectUpload handles POST /api/v1/shares/{id}/files/direct/init.
+//
+//	@Summary		Initiate a direct file upload
+//	@Description	Returns a presigned URL for direct upload to object storage. Only available when using S3-compatible storage.
+//	@Tags			files
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id		path		string					true	"Share ID (UUID)"
+//	@Param			body	body		directUploadInitRequest	true	"File metadata"
+//	@Success		200		{object}	APIResponse
+//	@Failure		400		{object}	APIResponse
+//	@Failure		401		{object}	APIResponse
+//	@Failure		404		{object}	APIResponse
+//	@Failure		409		{object}	APIResponse
+//	@Failure		500		{object}	APIResponse
+//	@Router			/api/v1/shares/{id}/files/direct/init [post]
+func (h *FileHandler) InitiateDirectUpload(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	if userID == "" {
+		Error(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	shareID := chi.URLParam(r, "id")
+	if shareID == "" {
+		Error(w, http.StatusBadRequest, "share ID is required")
+		return
+	}
+
+	// Verify share exists and user owns it
+	share, err := h.shareService.GetByID(r.Context(), shareID)
+	if err != nil {
+		if errors.Is(err, service.ErrShareNotFound) {
+			Error(w, http.StatusNotFound, "share not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to retrieve share")
+		return
+	}
+
+	if share.CreatorID == nil || *share.CreatorID != userID {
+		Error(w, http.StatusNotFound, "share not found")
+		return
+	}
+
+	var req directUploadInitRequest
+	if err := DecodeJSON(r, &req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Filename == "" {
+		Error(w, http.StatusBadRequest, "filename is required")
+		return
+	}
+	if req.Size <= 0 {
+		Error(w, http.StatusBadRequest, "size must be positive")
+		return
+	}
+
+	// Check file restrictions
+	effectiveMaxSize, blockedExtensions := loadEffectiveRestrictions(r.Context(), h.settingsRepo, h.maxFileSize)
+	if IsExtensionBlocked(req.Filename, blockedExtensions) {
+		Error(w, http.StatusBadRequest, "file extension is not allowed")
+		return
+	}
+	if req.Size > effectiveMaxSize {
+		Error(w, http.StatusBadRequest, "file exceeds maximum size limit")
+		return
+	}
+
+	input := service.DirectUploadInput{
+		ShareID:     shareID,
+		UploaderID:  userID,
+		Filename:    req.Filename,
+		Size:        req.Size,
+		ContentType: req.ContentType,
+	}
+
+	resp, err := h.fileService.InitiateDirectUpload(r.Context(), input)
+	if err != nil {
+		if errors.Is(err, service.ErrDirectTransferUnsupported) {
+			Error(w, http.StatusConflict, "direct transfer not supported, use standard upload")
+			return
+		}
+		if errors.Is(err, service.ErrInvalidFilename) || errors.Is(err, storage.ErrInvalidKey) {
+			Error(w, http.StatusBadRequest, "invalid filename")
+			return
+		}
+		slog.Error("failed to initiate direct upload", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to initiate upload")
+		return
+	}
+
+	Success(w, http.StatusOK, resp)
+}
+
+// directUploadFinalizeRequest is the JSON body for direct upload finalization.
+type directUploadFinalizeRequest struct {
+	UploadID string `json:"upload_id"`
+}
+
+// FinalizeDirectUpload handles POST /api/v1/shares/{id}/files/direct/finalize.
+//
+//	@Summary		Finalize a direct file upload
+//	@Description	Validates the uploaded file and creates the file record. Must be called after uploading to the presigned URL.
+//	@Tags			files
+//	@Accept			json
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Param			id		path		string						true	"Share ID (UUID)"
+//	@Param			body	body		directUploadFinalizeRequest	true	"Upload ID"
+//	@Success		201		{object}	APIResponse{data=fileResponse}
+//	@Failure		400		{object}	APIResponse
+//	@Failure		401		{object}	APIResponse
+//	@Failure		409		{object}	APIResponse
+//	@Failure		410		{object}	APIResponse
+//	@Failure		422		{object}	APIResponse
+//	@Failure		500		{object}	APIResponse
+//	@Router			/api/v1/shares/{id}/files/direct/finalize [post]
+func (h *FileHandler) FinalizeDirectUpload(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	if userID == "" {
+		Error(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	shareID := chi.URLParam(r, "id")
+	if shareID == "" {
+		Error(w, http.StatusBadRequest, "share ID is required")
+		return
+	}
+
+	// Verify share exists and user owns it
+	share, err := h.shareService.GetByID(r.Context(), shareID)
+	if err != nil {
+		if errors.Is(err, service.ErrShareNotFound) {
+			Error(w, http.StatusNotFound, "share not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to retrieve share")
+		return
+	}
+
+	if share.CreatorID == nil || *share.CreatorID != userID {
+		Error(w, http.StatusNotFound, "share not found")
+		return
+	}
+
+	var req directUploadFinalizeRequest
+	if err := DecodeJSON(r, &req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.UploadID == "" {
+		Error(w, http.StatusBadRequest, "upload_id is required")
+		return
+	}
+
+	file, err := h.fileService.FinalizeDirectUpload(r.Context(), req.UploadID)
+	if err != nil {
+		if errors.Is(err, service.ErrUploadNotFound) {
+			Error(w, http.StatusNotFound, "upload not found")
+			return
+		}
+		if errors.Is(err, service.ErrUploadAlreadyFinalized) {
+			Error(w, http.StatusConflict, "upload already finalized")
+			return
+		}
+		if errors.Is(err, service.ErrUploadExpired) {
+			Error(w, http.StatusGone, "upload has expired")
+			return
+		}
+		if errors.Is(err, service.ErrIntegrityCheckFailed) {
+			Error(w, http.StatusUnprocessableEntity, "uploaded file integrity check failed")
+			return
+		}
+		slog.Error("failed to finalize direct upload", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to finalize upload")
+		return
+	}
+
+	resp := fileResponse{
+		ID:       file.ID,
+		Name:     file.Name,
+		Size:     file.Size,
+		MimeType: file.MimeType,
+	}
+
+	if h.webhooks != nil && share.CreatorID != nil && *share.CreatorID != "" {
+		creatorID := *share.CreatorID
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			if err := h.webhooks.Emit(ctx, service.WebhookEvent{
+				Type:      "file.upload.completed",
+				CreatorID: creatorID,
+				ActorID:   userID,
+				Resource:  shareID,
+				Data: map[string]interface{}{
+					"share_id": shareID,
+					"count":    1,
+					"files": []map[string]interface{}{
+						{
+							"id":        file.ID,
+							"name":      file.Name,
+							"size":      file.Size,
+							"mime_type": file.MimeType,
+						},
+					},
+				},
+			}); err != nil {
+				slog.Warn("failed to emit webhook", "event_type", "file.upload.completed", "share_id", shareID, "error", err)
+			}
+		}()
+	}
+
+	Success(w, http.StatusCreated, resp)
 }

--- a/internal/handler/file_test.go
+++ b/internal/handler/file_test.go
@@ -22,10 +22,12 @@ import (
 
 // mockFileHandlerFileService implements FileHandlerFileService for testing.
 type mockFileHandlerFileService struct {
-	uploadFn      func(ctx context.Context, input service.UploadInput) (*model.File, error)
-	getByIDFn     func(ctx context.Context, id string) (*model.File, error)
-	deleteFn      func(ctx context.Context, id string) error
-	listByShareFn func(ctx context.Context, shareID string) ([]*model.File, error)
+	uploadFn               func(ctx context.Context, input service.UploadInput) (*model.File, error)
+	getByIDFn              func(ctx context.Context, id string) (*model.File, error)
+	deleteFn               func(ctx context.Context, id string) error
+	listByShareFn          func(ctx context.Context, shareID string) ([]*model.File, error)
+	initiateDirectUploadFn func(ctx context.Context, input service.DirectUploadInput) (*service.DirectUploadResponse, error)
+	finalizeDirectUploadFn func(ctx context.Context, uploadID string) (*model.File, error)
 }
 
 func (m *mockFileHandlerFileService) Upload(ctx context.Context, input service.UploadInput) (*model.File, error) {
@@ -52,6 +54,20 @@ func (m *mockFileHandlerFileService) Delete(ctx context.Context, id string) erro
 func (m *mockFileHandlerFileService) ListByShare(ctx context.Context, shareID string) ([]*model.File, error) {
 	if m.listByShareFn != nil {
 		return m.listByShareFn(ctx, shareID)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockFileHandlerFileService) InitiateDirectUpload(ctx context.Context, input service.DirectUploadInput) (*service.DirectUploadResponse, error) {
+	if m.initiateDirectUploadFn != nil {
+		return m.initiateDirectUploadFn(ctx, input)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockFileHandlerFileService) FinalizeDirectUpload(ctx context.Context, uploadID string) (*model.File, error) {
+	if m.finalizeDirectUploadFn != nil {
+		return m.finalizeDirectUploadFn(ctx, uploadID)
 	}
 	return nil, errors.New("not implemented")
 }

--- a/internal/handler/public.go
+++ b/internal/handler/public.go
@@ -42,6 +42,9 @@ type PublicFileServiceInterface interface {
 	GetByID(ctx context.Context, id string) (*model.File, error)
 	GetContent(ctx context.Context, id string) (io.ReadCloser, *model.File, error)
 	Upload(ctx context.Context, input service.UploadInput) (*model.File, error)
+	InitiateDirectUpload(ctx context.Context, input service.DirectUploadInput) (*service.DirectUploadResponse, error)
+	FinalizeDirectUpload(ctx context.Context, uploadID string) (*model.File, error)
+	GetPresignedDownloadURL(ctx context.Context, fileID string, disposition string) (*service.DirectDownloadResponse, error)
 }
 
 // PublicHandler handles public share-related HTTP requests (no auth required).
@@ -738,4 +741,318 @@ func (h *PublicHandler) toPublicFileResponseList(files []*model.File) []publicFi
 		}
 	}
 	return result
+}
+
+// DirectDownload handles GET /s/{slug}/files/{fileId}/direct - redirects to a presigned download URL.
+//
+//	@Summary		Direct download a file
+//	@Description	Returns a 302 redirect to a presigned download URL. Falls back to 409 if storage doesn't support direct transfer.
+//	@Tags			public
+//	@Param			slug	path	string	true	"Share slug"
+//	@Param			fileId	path	string	true	"File ID (UUID)"
+//	@Success		302
+//	@Failure		401	{object}	APIResponse
+//	@Failure		404	{object}	APIResponse
+//	@Failure		409	{object}	APIResponse
+//	@Failure		410	{object}	APIResponse
+//	@Failure		500	{object}	APIResponse
+//	@Router			/s/{slug}/files/{fileId}/direct [get]
+func (h *PublicHandler) DirectDownload(w http.ResponseWriter, r *http.Request) {
+	slug := chi.URLParam(r, "slug")
+	fileID := chi.URLParam(r, "fileId")
+
+	if slug == "" {
+		Error(w, http.StatusBadRequest, "slug is required")
+		return
+	}
+	if fileID == "" {
+		Error(w, http.StatusBadRequest, "file ID is required")
+		return
+	}
+
+	share, err := h.shareService.GetBySlug(r.Context(), slug)
+	if err != nil {
+		if errors.Is(err, service.ErrShareNotFound) {
+			Error(w, http.StatusNotFound, "share not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to retrieve share")
+		return
+	}
+
+	if err := h.shareService.ValidateAccess(r.Context(), share); err != nil {
+		h.handleAccessError(w, err)
+		return
+	}
+
+	if share.HasPassword() {
+		if err := h.validateShareToken(r, share.ID); err != nil {
+			Error(w, http.StatusUnauthorized, "password verification required")
+			return
+		}
+	}
+
+	file, err := h.fileService.GetByID(r.Context(), fileID)
+	if err != nil {
+		if errors.Is(err, service.ErrFileNotFound) {
+			Error(w, http.StatusNotFound, "file not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to retrieve file")
+		return
+	}
+
+	if file.ShareID != share.ID {
+		Error(w, http.StatusNotFound, "file not found")
+		return
+	}
+
+	disposition := mime.FormatMediaType("attachment", map[string]string{"filename": file.Name})
+
+	resp, err := h.fileService.GetPresignedDownloadURL(r.Context(), fileID, disposition)
+	if err != nil {
+		if errors.Is(err, service.ErrDirectTransferUnsupported) {
+			Error(w, http.StatusConflict, "direct transfer not supported, use standard download")
+			return
+		}
+		slog.Error("failed to generate presigned download URL", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to generate download URL")
+		return
+	}
+
+	// Increment download count
+	if err := h.shareService.IncrementDownloadCount(r.Context(), share.ID); err != nil {
+		slog.Warn("failed to increment download count", "share_id", share.ID, "error", err)
+	}
+
+	if h.webhooks != nil && share.CreatorID != nil && *share.CreatorID != "" {
+		creatorID := *share.CreatorID
+		go func(shareID, fID, fileName string) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			if err := h.webhooks.Emit(ctx, service.WebhookEvent{
+				Type:      "share.downloaded",
+				CreatorID: creatorID,
+				Resource:  shareID,
+				Data: map[string]interface{}{
+					"share_id": shareID,
+					"file_id":  fID,
+					"name":     fileName,
+				},
+			}); err != nil {
+				slog.Warn("failed to emit webhook", "event_type", "share.downloaded", "share_id", shareID, "file_id", fID, "error", err)
+			}
+		}(share.ID, file.ID, file.Name)
+	}
+
+	http.Redirect(w, r, resp.DownloadURL, http.StatusFound)
+}
+
+// InitiateReverseShareUpload handles POST /s/{slug}/upload/direct/init.
+//
+//	@Summary		Initiate direct upload to reverse share
+//	@Description	Returns a presigned URL for direct upload to a reverse share's storage.
+//	@Tags			public
+//	@Accept			json
+//	@Produce		json
+//	@Param			slug	path		string					true	"Share slug"
+//	@Param			body	body		directUploadInitRequest	true	"File metadata"
+//	@Success		200		{object}	APIResponse
+//	@Failure		400		{object}	APIResponse
+//	@Failure		403		{object}	APIResponse
+//	@Failure		404		{object}	APIResponse
+//	@Failure		409		{object}	APIResponse
+//	@Failure		410		{object}	APIResponse
+//	@Failure		500		{object}	APIResponse
+//	@Router			/s/{slug}/upload/direct/init [post]
+func (h *PublicHandler) InitiateReverseShareUpload(w http.ResponseWriter, r *http.Request) {
+	slug := chi.URLParam(r, "slug")
+	if slug == "" {
+		Error(w, http.StatusBadRequest, "slug is required")
+		return
+	}
+
+	share, err := h.shareService.GetBySlug(r.Context(), slug)
+	if err != nil {
+		if errors.Is(err, service.ErrShareNotFound) {
+			Error(w, http.StatusNotFound, "share not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to retrieve share")
+		return
+	}
+
+	if err := h.shareService.ValidateAccess(r.Context(), share); err != nil {
+		h.handleAccessError(w, err)
+		return
+	}
+
+	if !share.IsReverseShare {
+		Error(w, http.StatusForbidden, "share does not accept uploads")
+		return
+	}
+
+	var req directUploadInitRequest
+	if err := DecodeJSON(r, &req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Filename == "" {
+		Error(w, http.StatusBadRequest, "filename is required")
+		return
+	}
+	if req.Size <= 0 {
+		Error(w, http.StatusBadRequest, "size must be positive")
+		return
+	}
+
+	effectiveMaxSize, blockedExtensions := loadEffectiveRestrictions(r.Context(), h.settingsRepo, h.maxFileSize)
+	if IsExtensionBlocked(req.Filename, blockedExtensions) {
+		Error(w, http.StatusBadRequest, "file extension is not allowed")
+		return
+	}
+	if req.Size > effectiveMaxSize {
+		Error(w, http.StatusBadRequest, "file exceeds maximum size limit")
+		return
+	}
+
+	input := service.DirectUploadInput{
+		ShareID:     share.ID,
+		UploaderID:  "",
+		Filename:    req.Filename,
+		Size:        req.Size,
+		ContentType: req.ContentType,
+	}
+
+	resp, err := h.fileService.InitiateDirectUpload(r.Context(), input)
+	if err != nil {
+		if errors.Is(err, service.ErrDirectTransferUnsupported) {
+			Error(w, http.StatusConflict, "direct transfer not supported, use standard upload")
+			return
+		}
+		slog.Error("failed to initiate direct upload", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to initiate upload")
+		return
+	}
+
+	Success(w, http.StatusOK, resp)
+}
+
+// FinalizeReverseShareUpload handles POST /s/{slug}/upload/direct/finalize.
+//
+//	@Summary		Finalize direct upload to reverse share
+//	@Description	Validates the uploaded file and creates the file record for a reverse share direct upload.
+//	@Tags			public
+//	@Accept			json
+//	@Produce		json
+//	@Param			slug	path		string						true	"Share slug"
+//	@Param			body	body		directUploadFinalizeRequest	true	"Upload ID"
+//	@Success		201		{object}	APIResponse{data=publicFileResponse}
+//	@Failure		400		{object}	APIResponse
+//	@Failure		403		{object}	APIResponse
+//	@Failure		404		{object}	APIResponse
+//	@Failure		409		{object}	APIResponse
+//	@Failure		410		{object}	APIResponse
+//	@Failure		422		{object}	APIResponse
+//	@Failure		500		{object}	APIResponse
+//	@Router			/s/{slug}/upload/direct/finalize [post]
+func (h *PublicHandler) FinalizeReverseShareUpload(w http.ResponseWriter, r *http.Request) {
+	slug := chi.URLParam(r, "slug")
+	if slug == "" {
+		Error(w, http.StatusBadRequest, "slug is required")
+		return
+	}
+
+	share, err := h.shareService.GetBySlug(r.Context(), slug)
+	if err != nil {
+		if errors.Is(err, service.ErrShareNotFound) {
+			Error(w, http.StatusNotFound, "share not found")
+			return
+		}
+		Error(w, http.StatusInternalServerError, "failed to retrieve share")
+		return
+	}
+
+	if err := h.shareService.ValidateAccess(r.Context(), share); err != nil {
+		h.handleAccessError(w, err)
+		return
+	}
+
+	if !share.IsReverseShare {
+		Error(w, http.StatusForbidden, "share does not accept uploads")
+		return
+	}
+
+	var req directUploadFinalizeRequest
+	if err := DecodeJSON(r, &req); err != nil {
+		Error(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.UploadID == "" {
+		Error(w, http.StatusBadRequest, "upload_id is required")
+		return
+	}
+
+	file, err := h.fileService.FinalizeDirectUpload(r.Context(), req.UploadID)
+	if err != nil {
+		if errors.Is(err, service.ErrUploadNotFound) {
+			Error(w, http.StatusNotFound, "upload not found")
+			return
+		}
+		if errors.Is(err, service.ErrUploadAlreadyFinalized) {
+			Error(w, http.StatusConflict, "upload already finalized")
+			return
+		}
+		if errors.Is(err, service.ErrUploadExpired) {
+			Error(w, http.StatusGone, "upload has expired")
+			return
+		}
+		if errors.Is(err, service.ErrIntegrityCheckFailed) {
+			Error(w, http.StatusUnprocessableEntity, "uploaded file integrity check failed")
+			return
+		}
+		slog.Error("failed to finalize direct upload", "error", err)
+		Error(w, http.StatusInternalServerError, "failed to finalize upload")
+		return
+	}
+
+	resp := publicFileResponse{
+		ID:       file.ID,
+		Name:     file.Name,
+		Size:     file.Size,
+		MimeType: file.MimeType,
+	}
+
+	if h.webhooks != nil && share.CreatorID != nil && *share.CreatorID != "" {
+		creatorID := *share.CreatorID
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			if err := h.webhooks.Emit(ctx, service.WebhookEvent{
+				Type:      "file.upload.completed",
+				CreatorID: creatorID,
+				Resource:  share.ID,
+				Data: map[string]interface{}{
+					"share_id": share.ID,
+					"count":    1,
+					"files": []map[string]interface{}{
+						{
+							"id":        file.ID,
+							"name":      file.Name,
+							"size":      file.Size,
+							"mime_type": file.MimeType,
+						},
+					},
+				},
+			}); err != nil {
+				slog.Warn("failed to emit webhook", "event_type", "file.upload.completed", "share_id", share.ID, "error", err)
+			}
+		}()
+	}
+
+	Success(w, http.StatusCreated, resp)
 }

--- a/internal/handler/public_test.go
+++ b/internal/handler/public_test.go
@@ -78,10 +78,13 @@ func (m *mockPublicShareService) IncrementDownloadCount(ctx context.Context, id 
 
 // mockPublicFileService implements PublicFileServiceInterface for testing.
 type mockPublicFileService struct {
-	listByShareFn func(ctx context.Context, shareID string) ([]*model.File, error)
-	getByIDFn     func(ctx context.Context, id string) (*model.File, error)
-	getContentFn  func(ctx context.Context, id string) (io.ReadCloser, *model.File, error)
-	uploadFn      func(ctx context.Context, input service.UploadInput) (*model.File, error)
+	listByShareFn             func(ctx context.Context, shareID string) ([]*model.File, error)
+	getByIDFn                 func(ctx context.Context, id string) (*model.File, error)
+	getContentFn              func(ctx context.Context, id string) (io.ReadCloser, *model.File, error)
+	uploadFn                  func(ctx context.Context, input service.UploadInput) (*model.File, error)
+	initiateDirectUploadFn    func(ctx context.Context, input service.DirectUploadInput) (*service.DirectUploadResponse, error)
+	finalizeDirectUploadFn    func(ctx context.Context, uploadID string) (*model.File, error)
+	getPresignedDownloadURLFn func(ctx context.Context, fileID string, disposition string) (*service.DirectDownloadResponse, error)
 }
 
 func (m *mockPublicFileService) ListByShare(ctx context.Context, shareID string) ([]*model.File, error) {
@@ -108,6 +111,27 @@ func (m *mockPublicFileService) GetContent(ctx context.Context, id string) (io.R
 func (m *mockPublicFileService) Upload(ctx context.Context, input service.UploadInput) (*model.File, error) {
 	if m.uploadFn != nil {
 		return m.uploadFn(ctx, input)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPublicFileService) InitiateDirectUpload(ctx context.Context, input service.DirectUploadInput) (*service.DirectUploadResponse, error) {
+	if m.initiateDirectUploadFn != nil {
+		return m.initiateDirectUploadFn(ctx, input)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPublicFileService) FinalizeDirectUpload(ctx context.Context, uploadID string) (*model.File, error) {
+	if m.finalizeDirectUploadFn != nil {
+		return m.finalizeDirectUploadFn(ctx, uploadID)
+	}
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockPublicFileService) GetPresignedDownloadURL(ctx context.Context, fileID string, disposition string) (*service.DirectDownloadResponse, error) {
+	if m.getPresignedDownloadURLFn != nil {
+		return m.getPresignedDownloadURLFn(ctx, fileID, disposition)
 	}
 	return nil, errors.New("not implemented")
 }

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -178,6 +178,8 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 				// File routes for a specific share
 				r.With(intMiddleware.RequireScope("files:read")).Get("/files", fileHandler.ListByShare)
 				r.With(intMiddleware.RequireScope("files:write")).Post("/files", fileHandler.Upload)
+				r.With(intMiddleware.RequireScope("files:write")).Post("/files/direct/init", fileHandler.InitiateDirectUpload)
+				r.With(intMiddleware.RequireScope("files:write")).Post("/files/direct/finalize", fileHandler.FinalizeDirectUpload)
 			})
 		})
 
@@ -276,7 +278,10 @@ func NewRouter(cfg RouterConfig) *chi.Mux {
 		r.Post("/verify", publicHandler.VerifyPassword)
 		r.Get("/files/{fileId}", publicHandler.DownloadFile)
 		r.Get("/files/{fileId}/preview", publicHandler.PreviewFile)
+		r.Get("/files/{fileId}/direct", publicHandler.DirectDownload)
 		r.Post("/upload", publicHandler.UploadToReverseShare)
+		r.Post("/upload/direct/init", publicHandler.InitiateReverseShareUpload)
+		r.Post("/upload/direct/finalize", publicHandler.FinalizeReverseShareUpload)
 	})
 
 	// Swagger UI (API documentation)

--- a/internal/integration/testserver.go
+++ b/internal/integration/testserver.go
@@ -59,7 +59,7 @@ func NewTestServer(t *testing.T) *TestServer {
 	jwtSecret := []byte(testJWTSecret)
 	authService := service.NewAuthService(userRepo, jwtSecret)
 	shareService := service.NewShareService(shareRepo, fileRepo, store)
-	fileService := service.NewFileService(fileRepo, shareRepo, store)
+	fileService := service.NewFileService(fileRepo, shareRepo, store, nil, 0)
 	emailService := service.NewEmailService(service.SMTPConfig{}, recipientRepo, "http://localhost")
 	totpService := service.NewTOTPService(totpRepo, userRepo, jwtSecret)
 	apiKeyService := service.NewAPIKeyService(apiKeyRepo)

--- a/internal/model/pending_upload.go
+++ b/internal/model/pending_upload.go
@@ -1,0 +1,19 @@
+package model
+
+import "time"
+
+// PendingUpload represents a direct upload that has been initiated but not yet finalized.
+type PendingUpload struct {
+	ID          string
+	FileID      string
+	ShareID     string
+	UploaderID  *string
+	Filename    string
+	Size        int64
+	MimeType    string
+	StorageKey  string
+	Status      string
+	ExpiresAt   time.Time
+	CreatedAt   time.Time
+	FinalizedAt *time.Time
+}

--- a/internal/repository/pending_upload.go
+++ b/internal/repository/pending_upload.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/amalgamated-tools/enlace/internal/model"
+)
+
+// PendingUploadRepository provides CRUD operations for pending direct uploads.
+type PendingUploadRepository struct {
+	db *sql.DB
+}
+
+// NewPendingUploadRepository creates a new PendingUploadRepository instance.
+func NewPendingUploadRepository(db *sql.DB) *PendingUploadRepository {
+	return &PendingUploadRepository{db: db}
+}
+
+// Create inserts a new pending upload record.
+func (r *PendingUploadRepository) Create(ctx context.Context, pu *model.PendingUpload) error {
+	pu.CreatedAt = time.Now()
+
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO pending_uploads (id, file_id, share_id, uploader_id, filename, size, mime_type, storage_key, status, expires_at, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		pu.ID, pu.FileID, pu.ShareID, pu.UploaderID, pu.Filename, pu.Size, pu.MimeType, pu.StorageKey, pu.Status, pu.ExpiresAt, pu.CreatedAt,
+	)
+	return err
+}
+
+// GetByID retrieves a pending upload by its ID.
+func (r *PendingUploadRepository) GetByID(ctx context.Context, id string) (*model.PendingUpload, error) {
+	pu := &model.PendingUpload{}
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id, file_id, share_id, uploader_id, filename, size, mime_type, storage_key, status, expires_at, created_at, finalized_at
+		 FROM pending_uploads WHERE id = ?`, id,
+	).Scan(&pu.ID, &pu.FileID, &pu.ShareID, &pu.UploaderID, &pu.Filename, &pu.Size, &pu.MimeType, &pu.StorageKey, &pu.Status, &pu.ExpiresAt, &pu.CreatedAt, &pu.FinalizedAt)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	return pu, err
+}
+
+// Finalize atomically transitions a pending upload from "pending" to "finalized".
+// Returns ErrNotFound if the upload does not exist or is not in "pending" status.
+func (r *PendingUploadRepository) Finalize(ctx context.Context, id string) error {
+	now := time.Now()
+	result, err := r.db.ExecContext(ctx,
+		`UPDATE pending_uploads SET status = 'finalized', finalized_at = ? WHERE id = ? AND status = 'pending'`,
+		now, id,
+	)
+	if err != nil {
+		return err
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ExpireStale marks pending uploads that have passed their expiry as "expired"
+// and returns the number of rows affected.
+func (r *PendingUploadRepository) ExpireStale(ctx context.Context) (int64, error) {
+	result, err := r.db.ExecContext(ctx,
+		`UPDATE pending_uploads SET status = 'expired' WHERE status = 'pending' AND expires_at < ?`,
+		time.Now(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/internal/repository/pending_upload_test.go
+++ b/internal/repository/pending_upload_test.go
@@ -1,0 +1,198 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/amalgamated-tools/enlace/internal/database"
+	"github.com/amalgamated-tools/enlace/internal/model"
+	"github.com/amalgamated-tools/enlace/internal/repository"
+)
+
+func setupPendingUploadRepo(t *testing.T) (*repository.PendingUploadRepository, func()) {
+	t.Helper()
+	db, err := database.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+	repo := repository.NewPendingUploadRepository(db.DB())
+	return repo, func() { db.Close() }
+}
+
+func TestPendingUploadRepository_CreateAndGetByID(t *testing.T) {
+	repo, cleanup := setupPendingUploadRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pu := &model.PendingUpload{
+		ID:         "upload-1",
+		FileID:     "file-1",
+		ShareID:    "share-1",
+		Filename:   "test.txt",
+		Size:       1024,
+		MimeType:   "text/plain",
+		StorageKey: "share-1/file-1/test.txt",
+		Status:     "pending",
+		ExpiresAt:  time.Now().Add(10 * time.Minute),
+	}
+
+	if err := repo.Create(ctx, pu); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, "upload-1")
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+
+	if got.ID != "upload-1" {
+		t.Errorf("expected ID upload-1, got %s", got.ID)
+	}
+	if got.FileID != "file-1" {
+		t.Errorf("expected FileID file-1, got %s", got.FileID)
+	}
+	if got.Status != "pending" {
+		t.Errorf("expected status pending, got %s", got.Status)
+	}
+}
+
+func TestPendingUploadRepository_GetByID_NotFound(t *testing.T) {
+	repo, cleanup := setupPendingUploadRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, err := repo.GetByID(ctx, "nonexistent")
+	if err != repository.ErrNotFound {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestPendingUploadRepository_Finalize(t *testing.T) {
+	repo, cleanup := setupPendingUploadRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pu := &model.PendingUpload{
+		ID:         "upload-2",
+		FileID:     "file-2",
+		ShareID:    "share-1",
+		Filename:   "test.txt",
+		Size:       1024,
+		MimeType:   "text/plain",
+		StorageKey: "share-1/file-2/test.txt",
+		Status:     "pending",
+		ExpiresAt:  time.Now().Add(10 * time.Minute),
+	}
+
+	if err := repo.Create(ctx, pu); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if err := repo.Finalize(ctx, "upload-2"); err != nil {
+		t.Fatalf("Finalize failed: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, "upload-2")
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+
+	if got.Status != "finalized" {
+		t.Errorf("expected status finalized, got %s", got.Status)
+	}
+	if got.FinalizedAt == nil {
+		t.Error("expected FinalizedAt to be set")
+	}
+}
+
+func TestPendingUploadRepository_Finalize_AlreadyFinalized(t *testing.T) {
+	repo, cleanup := setupPendingUploadRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	pu := &model.PendingUpload{
+		ID:         "upload-3",
+		FileID:     "file-3",
+		ShareID:    "share-1",
+		Filename:   "test.txt",
+		Size:       1024,
+		MimeType:   "text/plain",
+		StorageKey: "share-1/file-3/test.txt",
+		Status:     "pending",
+		ExpiresAt:  time.Now().Add(10 * time.Minute),
+	}
+
+	if err := repo.Create(ctx, pu); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if err := repo.Finalize(ctx, "upload-3"); err != nil {
+		t.Fatalf("first Finalize failed: %v", err)
+	}
+
+	// Second finalize should fail
+	err := repo.Finalize(ctx, "upload-3")
+	if err != repository.ErrNotFound {
+		t.Errorf("expected ErrNotFound on double finalize, got %v", err)
+	}
+}
+
+func TestPendingUploadRepository_ExpireStale(t *testing.T) {
+	repo, cleanup := setupPendingUploadRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create an already-expired upload
+	pu := &model.PendingUpload{
+		ID:         "upload-expired",
+		FileID:     "file-expired",
+		ShareID:    "share-1",
+		Filename:   "old.txt",
+		Size:       512,
+		MimeType:   "text/plain",
+		StorageKey: "share-1/file-expired/old.txt",
+		Status:     "pending",
+		ExpiresAt:  time.Now().Add(-1 * time.Minute),
+	}
+	if err := repo.Create(ctx, pu); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Create a still-valid upload
+	pu2 := &model.PendingUpload{
+		ID:         "upload-valid",
+		FileID:     "file-valid",
+		ShareID:    "share-1",
+		Filename:   "new.txt",
+		Size:       512,
+		MimeType:   "text/plain",
+		StorageKey: "share-1/file-valid/new.txt",
+		Status:     "pending",
+		ExpiresAt:  time.Now().Add(10 * time.Minute),
+	}
+	if err := repo.Create(ctx, pu2); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	affected, err := repo.ExpireStale(ctx)
+	if err != nil {
+		t.Fatalf("ExpireStale failed: %v", err)
+	}
+	if affected != 1 {
+		t.Errorf("expected 1 expired, got %d", affected)
+	}
+
+	// Verify expired
+	got, _ := repo.GetByID(ctx, "upload-expired")
+	if got.Status != "expired" {
+		t.Errorf("expected status expired, got %s", got.Status)
+	}
+
+	// Verify still-valid is untouched
+	got2, _ := repo.GetByID(ctx, "upload-valid")
+	if got2.Status != "pending" {
+		t.Errorf("expected status pending, got %s", got2.Status)
+	}
+}

--- a/internal/service/file.go
+++ b/internal/service/file.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -21,11 +22,28 @@ var ErrFileNotFound = errors.New("file not found")
 // ErrInvalidFilename is returned when an uploaded filename is not valid.
 var ErrInvalidFilename = errors.New("invalid filename")
 
+// ErrDirectTransferUnsupported is returned when the storage backend does not support direct transfer.
+var ErrDirectTransferUnsupported = errors.New("direct transfer not supported by current storage backend")
+
+// ErrUploadNotFound is returned when a pending upload does not exist.
+var ErrUploadNotFound = errors.New("pending upload not found")
+
+// ErrUploadExpired is returned when a pending upload has passed its expiry.
+var ErrUploadExpired = errors.New("pending upload has expired")
+
+// ErrUploadAlreadyFinalized is returned when a pending upload has already been finalized.
+var ErrUploadAlreadyFinalized = errors.New("upload already finalized")
+
+// ErrIntegrityCheckFailed is returned when the uploaded object does not match expected metadata.
+var ErrIntegrityCheckFailed = errors.New("uploaded file integrity check failed")
+
 // FileService handles file-related business logic.
 type FileService struct {
-	fileRepo  *repository.FileRepository
-	shareRepo *repository.ShareRepository
-	storage   storage.Storage
+	fileRepo          *repository.FileRepository
+	shareRepo         *repository.ShareRepository
+	storage           storage.Storage
+	pendingUploadRepo *repository.PendingUploadRepository
+	presignExpiry     time.Duration
 }
 
 // UploadInput contains the data required to upload a file.
@@ -37,16 +55,44 @@ type UploadInput struct {
 	Size       int64
 }
 
+// DirectUploadInput contains the data required to initiate a direct upload.
+type DirectUploadInput struct {
+	ShareID     string
+	UploaderID  string
+	Filename    string
+	Size        int64
+	ContentType string
+}
+
+// DirectUploadResponse is returned when a direct upload is initiated.
+type DirectUploadResponse struct {
+	UploadID  string    `json:"upload_id"`
+	UploadURL string    `json:"upload_url"`
+	FileID    string    `json:"file_id"`
+	Method    string    `json:"method"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// DirectDownloadResponse is returned when a presigned download URL is generated.
+type DirectDownloadResponse struct {
+	DownloadURL string    `json:"download_url"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
 // NewFileService creates a new FileService instance.
 func NewFileService(
 	fileRepo *repository.FileRepository,
 	shareRepo *repository.ShareRepository,
 	store storage.Storage,
+	pendingUploadRepo *repository.PendingUploadRepository,
+	presignExpiry time.Duration,
 ) *FileService {
 	return &FileService{
-		fileRepo:  fileRepo,
-		shareRepo: shareRepo,
-		storage:   store,
+		fileRepo:          fileRepo,
+		shareRepo:         shareRepo,
+		storage:           store,
+		pendingUploadRepo: pendingUploadRepo,
+		presignExpiry:     presignExpiry,
 	}
 }
 
@@ -174,6 +220,179 @@ func (s *FileService) GetContent(ctx context.Context, id string) (io.ReadCloser,
 // Returns true for: images (jpeg, png, gif, svg, webp), PDF, and text files.
 func (s *FileService) IsPreviewable(file *model.File) bool {
 	return isPreviewableMimeType(file.MimeType)
+}
+
+// maxPresignExpiry caps the configurable expiry to prevent excessively long-lived URLs.
+const maxPresignExpiry = 60 * time.Minute
+
+// clampExpiry ensures the expiry does not exceed the maximum.
+func clampExpiry(d time.Duration) time.Duration {
+	if d > maxPresignExpiry {
+		return maxPresignExpiry
+	}
+	return d
+}
+
+// InitiateDirectUpload creates a pending upload and returns a presigned PUT URL.
+func (s *FileService) InitiateDirectUpload(ctx context.Context, input DirectUploadInput) (*DirectUploadResponse, error) {
+	dt, ok := s.storage.(storage.DirectTransfer)
+	if !ok {
+		return nil, ErrDirectTransferUnsupported
+	}
+
+	// Verify share exists
+	_, err := s.shareRepo.GetByID(ctx, input.ShareID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrShareNotFound
+		}
+		return nil, err
+	}
+
+	filename, err := sanitizeFilename(input.Filename)
+	if err != nil {
+		return nil, err
+	}
+
+	fileID := uuid.NewString()
+	uploadID := uuid.NewString()
+
+	mimeType := input.ContentType
+	if mimeType == "" {
+		mimeType = detectMimeType(filename)
+	}
+
+	storageKey := input.ShareID + "/" + fileID + "/" + filename
+
+	expiry := clampExpiry(s.presignExpiry)
+
+	presigned, err := dt.PresignUpload(ctx, storageKey, input.Size, mimeType, expiry)
+	if err != nil {
+		return nil, err
+	}
+
+	var uploaderID *string
+	if input.UploaderID != "" {
+		uploaderID = &input.UploaderID
+	}
+
+	pu := &model.PendingUpload{
+		ID:         uploadID,
+		FileID:     fileID,
+		ShareID:    input.ShareID,
+		UploaderID: uploaderID,
+		Filename:   filename,
+		Size:       input.Size,
+		MimeType:   mimeType,
+		StorageKey: storageKey,
+		Status:     "pending",
+		ExpiresAt:  presigned.ExpiresAt,
+	}
+
+	if err := s.pendingUploadRepo.Create(ctx, pu); err != nil {
+		return nil, err
+	}
+
+	return &DirectUploadResponse{
+		UploadID:  uploadID,
+		UploadURL: presigned.URL,
+		FileID:    fileID,
+		Method:    presigned.Method,
+		ExpiresAt: presigned.ExpiresAt,
+	}, nil
+}
+
+// FinalizeDirectUpload validates a completed direct upload and creates the file record.
+func (s *FileService) FinalizeDirectUpload(ctx context.Context, uploadID string) (*model.File, error) {
+	dt, ok := s.storage.(storage.DirectTransfer)
+	if !ok {
+		return nil, ErrDirectTransferUnsupported
+	}
+
+	pu, err := s.pendingUploadRepo.GetByID(ctx, uploadID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrUploadNotFound
+		}
+		return nil, err
+	}
+
+	if pu.Status == "finalized" {
+		return nil, ErrUploadAlreadyFinalized
+	}
+	if pu.Status != "pending" {
+		return nil, ErrUploadExpired
+	}
+	if time.Now().After(pu.ExpiresAt) {
+		return nil, ErrUploadExpired
+	}
+
+	// Verify the object was actually uploaded and matches expected metadata
+	info, err := dt.StatObject(ctx, pu.StorageKey)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, ErrIntegrityCheckFailed
+		}
+		return nil, err
+	}
+
+	if info.Size != pu.Size {
+		// Orphaned object — attempt cleanup
+		_ = s.storage.Delete(ctx, pu.StorageKey)
+		return nil, ErrIntegrityCheckFailed
+	}
+
+	// Atomically mark as finalized (prevents replay)
+	if err := s.pendingUploadRepo.Finalize(ctx, uploadID); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrUploadAlreadyFinalized
+		}
+		return nil, err
+	}
+
+	file := &model.File{
+		ID:         pu.FileID,
+		ShareID:    pu.ShareID,
+		UploaderID: pu.UploaderID,
+		Name:       pu.Filename,
+		Size:       pu.Size,
+		MimeType:   pu.MimeType,
+		StorageKey: pu.StorageKey,
+	}
+
+	if err := s.fileRepo.Create(ctx, file); err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// GetPresignedDownloadURL returns a presigned download URL for a file.
+func (s *FileService) GetPresignedDownloadURL(ctx context.Context, fileID string, disposition string) (*DirectDownloadResponse, error) {
+	dt, ok := s.storage.(storage.DirectTransfer)
+	if !ok {
+		return nil, ErrDirectTransferUnsupported
+	}
+
+	file, err := s.fileRepo.GetByID(ctx, fileID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrFileNotFound
+		}
+		return nil, err
+	}
+
+	expiry := clampExpiry(s.presignExpiry)
+
+	presigned, err := dt.PresignDownload(ctx, file.StorageKey, disposition, expiry)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DirectDownloadResponse{
+		DownloadURL: presigned.URL,
+		ExpiresAt:   presigned.ExpiresAt,
+	}, nil
 }
 
 func sanitizeFilename(name string) (string, error) {

--- a/internal/service/file_test.go
+++ b/internal/service/file_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/amalgamated-tools/enlace/internal/database"
 	"github.com/amalgamated-tools/enlace/internal/model"
@@ -80,7 +81,7 @@ func setupFileService(t *testing.T) (*service.FileService, *testStorage, *reposi
 	shareRepo := repository.NewShareRepository(db.DB())
 	fileRepo := repository.NewFileRepository(db.DB())
 	store := newTestStorage()
-	fileService := service.NewFileService(fileRepo, shareRepo, store)
+	fileService := service.NewFileService(fileRepo, shareRepo, store, nil, 0)
 
 	return fileService, store, shareRepo, func() { db.Close() }
 }
@@ -119,7 +120,7 @@ func setupFileServiceWithUserAndShare(t *testing.T) (*service.FileService, *test
 		t.Fatalf("failed to create test share: %v", err)
 	}
 
-	fileService := service.NewFileService(fileRepo, shareRepo, store)
+	fileService := service.NewFileService(fileRepo, shareRepo, store, nil, 0)
 
 	return fileService, store, share, func() { db.Close() }
 }
@@ -685,5 +686,291 @@ func TestFileService_Upload_SpecialCharactersInFilename(t *testing.T) {
 				t.Errorf("expected filename %q, got %q", filename, file.Name)
 			}
 		})
+	}
+}
+
+// testDirectTransferStorage implements both storage.Storage and storage.DirectTransfer for testing.
+type testDirectTransferStorage struct {
+	testStorage
+	presignUploadFn   func(ctx context.Context, key string, size int64, contentType string, expiry time.Duration) (*storage.PresignedURLResult, error)
+	presignDownloadFn func(ctx context.Context, key string, disposition string, expiry time.Duration) (*storage.PresignedURLResult, error)
+	statObjectFn      func(ctx context.Context, key string) (*storage.ObjectInfo, error)
+}
+
+func (s *testDirectTransferStorage) PresignUpload(ctx context.Context, key string, size int64, contentType string, expiry time.Duration) (*storage.PresignedURLResult, error) {
+	if s.presignUploadFn != nil {
+		return s.presignUploadFn(ctx, key, size, contentType, expiry)
+	}
+	return &storage.PresignedURLResult{
+		URL:       "https://s3.example.com/presigned-put?key=" + key,
+		Method:    "PUT",
+		ExpiresAt: time.Now().Add(expiry),
+	}, nil
+}
+
+func (s *testDirectTransferStorage) PresignDownload(ctx context.Context, key string, disposition string, expiry time.Duration) (*storage.PresignedURLResult, error) {
+	if s.presignDownloadFn != nil {
+		return s.presignDownloadFn(ctx, key, disposition, expiry)
+	}
+	return &storage.PresignedURLResult{
+		URL:       "https://s3.example.com/presigned-get?key=" + key,
+		Method:    "GET",
+		ExpiresAt: time.Now().Add(expiry),
+	}, nil
+}
+
+func (s *testDirectTransferStorage) StatObject(ctx context.Context, key string) (*storage.ObjectInfo, error) {
+	if s.statObjectFn != nil {
+		return s.statObjectFn(ctx, key)
+	}
+	data, ok := s.files[key]
+	if !ok {
+		return nil, storage.ErrNotFound
+	}
+	return &storage.ObjectInfo{
+		Size:        int64(len(data)),
+		ContentType: "application/octet-stream",
+	}, nil
+}
+
+func setupDirectTransferService(t *testing.T) (*service.FileService, *testDirectTransferStorage, *model.Share, func()) {
+	t.Helper()
+	db, err := database.New(":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test db: %v", err)
+	}
+
+	userRepo := repository.NewUserRepository(db.DB())
+	shareRepo := repository.NewShareRepository(db.DB())
+	fileRepo := repository.NewFileRepository(db.DB())
+	pendingUploadRepo := repository.NewPendingUploadRepository(db.DB())
+	store := &testDirectTransferStorage{testStorage: testStorage{files: make(map[string][]byte)}}
+
+	user := &model.User{
+		ID:           "user-dt",
+		Email:        "dt@example.com",
+		PasswordHash: "hash",
+		DisplayName:  "DT User",
+	}
+	if err := userRepo.Create(context.Background(), user); err != nil {
+		t.Fatalf("failed to create test user: %v", err)
+	}
+
+	share := &model.Share{
+		ID:        "share-dt",
+		CreatorID: &user.ID,
+		Slug:      "dt-share",
+		Name:      "DT Share",
+	}
+	if err := shareRepo.Create(context.Background(), share); err != nil {
+		t.Fatalf("failed to create test share: %v", err)
+	}
+
+	fileService := service.NewFileService(fileRepo, shareRepo, store, pendingUploadRepo, 10*time.Minute)
+
+	return fileService, store, share, func() { db.Close() }
+}
+
+func TestFileService_InitiateDirectUpload(t *testing.T) {
+	svc, _, share, cleanup := setupDirectTransferService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	input := service.DirectUploadInput{
+		ShareID:     share.ID,
+		UploaderID:  *share.CreatorID,
+		Filename:    "direct.txt",
+		Size:        2048,
+		ContentType: "text/plain",
+	}
+
+	resp, err := svc.InitiateDirectUpload(ctx, input)
+	if err != nil {
+		t.Fatalf("InitiateDirectUpload failed: %v", err)
+	}
+
+	if resp.UploadID == "" {
+		t.Error("expected upload_id to be set")
+	}
+	if resp.UploadURL == "" {
+		t.Error("expected upload_url to be set")
+	}
+	if resp.FileID == "" {
+		t.Error("expected file_id to be set")
+	}
+	if resp.Method != "PUT" {
+		t.Errorf("expected method PUT, got %s", resp.Method)
+	}
+}
+
+func TestFileService_InitiateDirectUpload_UnsupportedStorage(t *testing.T) {
+	svc, _, _, cleanup := setupFileServiceWithUserAndShare(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	input := service.DirectUploadInput{
+		ShareID:  "share-123",
+		Filename: "test.txt",
+		Size:     1024,
+	}
+
+	_, err := svc.InitiateDirectUpload(ctx, input)
+	if !errors.Is(err, service.ErrDirectTransferUnsupported) {
+		t.Errorf("expected ErrDirectTransferUnsupported, got %v", err)
+	}
+}
+
+func TestFileService_FinalizeDirectUpload(t *testing.T) {
+	svc, store, share, cleanup := setupDirectTransferService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	input := service.DirectUploadInput{
+		ShareID:     share.ID,
+		UploaderID:  *share.CreatorID,
+		Filename:    "finalize.txt",
+		Size:        5,
+		ContentType: "text/plain",
+	}
+
+	resp, err := svc.InitiateDirectUpload(ctx, input)
+	if err != nil {
+		t.Fatalf("InitiateDirectUpload failed: %v", err)
+	}
+
+	// Simulate the client uploading to S3 by putting data in our mock store
+	store.files[share.ID+"/"+resp.FileID+"/finalize.txt"] = []byte("hello")
+
+	file, err := svc.FinalizeDirectUpload(ctx, resp.UploadID)
+	if err != nil {
+		t.Fatalf("FinalizeDirectUpload failed: %v", err)
+	}
+
+	if file.ID != resp.FileID {
+		t.Errorf("expected file ID %s, got %s", resp.FileID, file.ID)
+	}
+	if file.Name != "finalize.txt" {
+		t.Errorf("expected name finalize.txt, got %s", file.Name)
+	}
+	if file.Size != 5 {
+		t.Errorf("expected size 5, got %d", file.Size)
+	}
+}
+
+func TestFileService_FinalizeDirectUpload_AlreadyFinalized(t *testing.T) {
+	svc, store, share, cleanup := setupDirectTransferService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	input := service.DirectUploadInput{
+		ShareID:    share.ID,
+		UploaderID: *share.CreatorID,
+		Filename:   "double.txt",
+		Size:       3,
+	}
+
+	resp, _ := svc.InitiateDirectUpload(ctx, input)
+	store.files[share.ID+"/"+resp.FileID+"/double.txt"] = []byte("abc")
+
+	_, err := svc.FinalizeDirectUpload(ctx, resp.UploadID)
+	if err != nil {
+		t.Fatalf("first FinalizeDirectUpload failed: %v", err)
+	}
+
+	_, err = svc.FinalizeDirectUpload(ctx, resp.UploadID)
+	if !errors.Is(err, service.ErrUploadAlreadyFinalized) {
+		t.Errorf("expected ErrUploadAlreadyFinalized, got %v", err)
+	}
+}
+
+func TestFileService_FinalizeDirectUpload_IntegrityCheckFailed(t *testing.T) {
+	svc, store, share, cleanup := setupDirectTransferService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	input := service.DirectUploadInput{
+		ShareID:    share.ID,
+		UploaderID: *share.CreatorID,
+		Filename:   "mismatch.txt",
+		Size:       100,
+	}
+
+	resp, _ := svc.InitiateDirectUpload(ctx, input)
+	// Put data with wrong size
+	store.files[share.ID+"/"+resp.FileID+"/mismatch.txt"] = []byte("short")
+
+	_, err := svc.FinalizeDirectUpload(ctx, resp.UploadID)
+	if !errors.Is(err, service.ErrIntegrityCheckFailed) {
+		t.Errorf("expected ErrIntegrityCheckFailed, got %v", err)
+	}
+}
+
+func TestFileService_FinalizeDirectUpload_ObjectNotUploaded(t *testing.T) {
+	svc, _, share, cleanup := setupDirectTransferService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	input := service.DirectUploadInput{
+		ShareID:    share.ID,
+		UploaderID: *share.CreatorID,
+		Filename:   "missing.txt",
+		Size:       100,
+	}
+
+	resp, _ := svc.InitiateDirectUpload(ctx, input)
+	// Don't put any data in store
+
+	_, err := svc.FinalizeDirectUpload(ctx, resp.UploadID)
+	if !errors.Is(err, service.ErrIntegrityCheckFailed) {
+		t.Errorf("expected ErrIntegrityCheckFailed, got %v", err)
+	}
+}
+
+func TestFileService_GetPresignedDownloadURL(t *testing.T) {
+	svc, _, share, cleanup := setupDirectTransferService(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Upload a file via the standard path first
+	input := service.UploadInput{
+		ShareID:    share.ID,
+		UploaderID: *share.CreatorID,
+		Filename:   "download-me.txt",
+		Content:    strings.NewReader("content"),
+		Size:       7,
+	}
+	uploaded, err := svc.Upload(ctx, input)
+	if err != nil {
+		t.Fatalf("Upload failed: %v", err)
+	}
+
+	resp, err := svc.GetPresignedDownloadURL(ctx, uploaded.ID, "attachment; filename=\"download-me.txt\"")
+	if err != nil {
+		t.Fatalf("GetPresignedDownloadURL failed: %v", err)
+	}
+
+	if resp.DownloadURL == "" {
+		t.Error("expected download URL to be set")
+	}
+}
+
+func TestFileService_GetPresignedDownloadURL_UnsupportedStorage(t *testing.T) {
+	svc, _, share, cleanup := setupFileServiceWithUserAndShare(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	input := service.UploadInput{
+		ShareID:    share.ID,
+		UploaderID: *share.CreatorID,
+		Filename:   "no-direct.txt",
+		Content:    strings.NewReader("content"),
+		Size:       7,
+	}
+	uploaded, _ := svc.Upload(ctx, input)
+
+	_, err := svc.GetPresignedDownloadURL(ctx, uploaded.ID, "attachment")
+	if !errors.Is(err, service.ErrDirectTransferUnsupported) {
+		t.Errorf("expected ErrDirectTransferUnsupported, got %v", err)
 	}
 }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"path"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -15,6 +16,9 @@ import (
 
 // Compile-time check that S3Storage implements Storage interface.
 var _ Storage = (*S3Storage)(nil)
+
+// Compile-time check that S3Storage implements DirectTransfer interface.
+var _ DirectTransfer = (*S3Storage)(nil)
 
 // S3Storage implements the Storage interface using S3 or S3-compatible services.
 // It supports custom endpoints for services like MinIO, Backblaze B2, and Cloudflare R2.
@@ -211,4 +215,79 @@ func isNotFoundError(err error) bool {
 	}
 
 	return false
+}
+
+// PresignUpload returns a short-lived presigned PUT URL for direct upload.
+func (s *S3Storage) PresignUpload(ctx context.Context, key string, size int64, contentType string, expiry time.Duration) (*PresignedURLResult, error) {
+	presignClient := s3.NewPresignClient(s.client)
+
+	input := &s3.PutObjectInput{
+		Bucket:        aws.String(s.bucket),
+		Key:           aws.String(s.fullKey(key)),
+		ContentLength: aws.Int64(size),
+	}
+	if contentType != "" {
+		input.ContentType = aws.String(contentType)
+	}
+
+	result, err := presignClient.PresignPutObject(ctx, input, s3.WithPresignExpires(expiry))
+	if err != nil {
+		return nil, err
+	}
+
+	return &PresignedURLResult{
+		URL:       result.URL,
+		Method:    result.Method,
+		ExpiresAt: time.Now().Add(expiry),
+	}, nil
+}
+
+// PresignDownload returns a short-lived presigned GET URL for direct download.
+func (s *S3Storage) PresignDownload(ctx context.Context, key string, disposition string, expiry time.Duration) (*PresignedURLResult, error) {
+	presignClient := s3.NewPresignClient(s.client)
+
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(s.fullKey(key)),
+	}
+	if disposition != "" {
+		input.ResponseContentDisposition = aws.String(disposition)
+	}
+
+	result, err := presignClient.PresignGetObject(ctx, input, s3.WithPresignExpires(expiry))
+	if err != nil {
+		return nil, err
+	}
+
+	return &PresignedURLResult{
+		URL:       result.URL,
+		Method:    result.Method,
+		ExpiresAt: time.Now().Add(expiry),
+	}, nil
+}
+
+// StatObject retrieves metadata about an object without downloading it.
+func (s *S3Storage) StatObject(ctx context.Context, key string) (*ObjectInfo, error) {
+	input := &s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(s.fullKey(key)),
+	}
+
+	output, err := s.client.HeadObject(ctx, input)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	info := &ObjectInfo{}
+	if output.ContentLength != nil {
+		info.Size = *output.ContentLength
+	}
+	if output.ContentType != nil {
+		info.ContentType = *output.ContentType
+	}
+
+	return info, nil
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 )
 
 // ErrNotFound is returned when a requested file does not exist in storage.
@@ -36,4 +37,36 @@ type Storage interface {
 	// Exists checks if data exists for the given key.
 	// Returns true if the key exists, false otherwise.
 	Exists(ctx context.Context, key string) (bool, error)
+}
+
+// PresignedURLResult holds a presigned URL and its metadata.
+type PresignedURLResult struct {
+	URL       string
+	Method    string
+	ExpiresAt time.Time
+}
+
+// ObjectInfo holds metadata about a stored object.
+type ObjectInfo struct {
+	Size        int64
+	ContentType string
+}
+
+// DirectTransfer extends Storage with presigned URL capabilities.
+// Backends that support direct client-to-storage transfers (e.g. S3)
+// implement this interface. Backends that do not (e.g. local filesystem)
+// only implement Storage, and callers use a type assertion to detect support.
+type DirectTransfer interface {
+	Storage
+
+	// PresignUpload returns a short-lived presigned PUT URL for direct upload.
+	// The URL enforces the declared size and content type.
+	PresignUpload(ctx context.Context, key string, size int64, contentType string, expiry time.Duration) (*PresignedURLResult, error)
+
+	// PresignDownload returns a short-lived presigned GET URL for direct download.
+	// The disposition parameter sets the Content-Disposition header on the response.
+	PresignDownload(ctx context.Context, key string, disposition string, expiry time.Duration) (*PresignedURLResult, error)
+
+	// StatObject retrieves metadata about an object without downloading it.
+	StatObject(ctx context.Context, key string) (*ObjectInfo, error)
 }


### PR DESCRIPTION
Add optional direct upload/download via short-lived presigned S3 URLs, allowing clients to transfer files directly with object storage while keeping auth and validation server-side.

Implements DirectTransfer interface with PresignUpload, PresignDownload, and StatObject methods; S3Storage implements it natively while LocalStorage gracefully falls back to proxy mode. Adds pending_uploads table with atomic finalize for replay prevention and integrity checks via HeadObject. Includes 5 new endpoints (direct init/finalize for authenticated shares and public reverse shares, plus direct download with 302 redirect), comprehensive test coverage across all layers, and frontend fallback pattern that attempts direct transfer first, seamlessly falling back to proxy upload on 409 or error. Presigned URLs expire in 10 minutes (configurable via DIRECT_TRANSFER_EXPIRY_SECONDS).