### PR TITLE
Fix invalid component object error in router

### DIFF
--- a/frontend/src/routes.ts
+++ b/frontend/src/routes.ts
@@ -25,7 +25,7 @@ export default {
   "/shares": Shares,
   "/shares/new": NewShare,
   "/shares/:id": ShareDetail,
-  "/settings": "/settings/profile",
+  "/settings": SettingsProfile,
   "/settings/profile": SettingsProfile,
   "/settings/security": SettingsSecurity,
   "/settings/api-keys": SettingsApiKeys,


### PR DESCRIPTION
## Summary
Fixed svelte-spa-router error caused by string redirect in routes configuration. The `/settings` route was incorrectly mapped to a string `"/settings/profile"` instead of a component object, causing "Invalid component object" error on app load.

## Changes
Changed `/settings` route to map directly to `SettingsProfile` component, matching the `/settings/profile` route behavior without using string redirects.