### PR TITLE
docs: set up MkDocs Material documentation site

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,28 +1,21 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+# Build MkDocs documentation and deploy to GitHub Pages
+name: Deploy documentation to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -31,13 +24,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Build documentation
+        run: mkdocs build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: 'site'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ enlace.db
 e2e/node_modules/
 e2e/test-results/
 e2e/playwright-report/
+
+# MkDocs build output
+site/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Enlace Documentation
 
+Enlace is a self-hosted link shortener and bookmark manager. This documentation covers setup, configuration, and all available features.
+
 | Document | Description |
 |---|---|
 | [Configuration](configuration.md) | Environment variables, CLI flags, reverse proxy setup |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,42 @@
+site_name: Enlace
+site_url: https://amalgamated-tools.github.io/enlace
+repo_url: https://github.com/amalgamated-tools/enlace
+repo_name: amalgamated-tools/enlace
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: README.md
+  - Configuration: configuration.md
+  - API Reference: api.md
+  - Architecture: architecture.md
+  - Deployment: deployment.md
+  - Development: development.md
+  - OIDC / SSO: oidc.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - admonition
+  - pymdownx.details
+  - toc:
+      permalink: true
+  - tables


### PR DESCRIPTION
## Summary
- Set up MkDocs with Material theme for a polished documentation site at amalgamated-tools.github.io/enlace
- Updated GitHub Pages workflow to build and deploy the documentation site instead of the entire repository
- Added mkdocs.yml with Material theme featuring dark mode toggle, built-in search, code copy buttons, and responsive navigation
- Added site/ to .gitignore to prevent build output from being committed
- Updated docs/README.md with a brief introduction for the homepage

The existing 6 markdown documentation files are compatible with MkDocs and render without modification.